### PR TITLE
🩹 [Patch]: Default PowerShellVersion set to '5.1'

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -23,17 +23,14 @@ function Build-PSModuleDocumentation {
         [System.IO.DirectoryInfo] $DocsOutputFolder
     )
 
-    Start-LogGroup 'Docs - Dependencies'
+    Start-LogGroup 'Build docs - Dependencies'
     $moduleName = Split-Path -Path $ModuleOutputFolder -Leaf
 
     Add-PSModulePath -Path (Split-Path -Path $ModuleOutputFolder -Parent)
     Import-PSModule -Path $ModuleOutputFolder -ModuleName $moduleName
 
-    Start-LogGroup 'Build documentation'
+    Start-LogGroup 'Build docs - Generate markdown help'
     $null = New-MarkdownHelp -Module $moduleName -OutputFolder $DocsOutputFolder -Force -Verbose
-    Stop-LogGroup
-
-    Start-LogGroup 'Build documentation - Fix fence'
     Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
         $content = Get-Content -Path $_.FullName
         $fixedOpening = $false
@@ -51,15 +48,6 @@ function Build-PSModuleDocumentation {
         }
         $newContent | Set-Content -Path $_.FullName
     }
-    Stop-LogGroup
-
-    Start-LogGroup 'Build documentation - Result'
-    Write-Verbose (Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
-        @{
-            Name = $_.FullName
-            Hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash
-        }
-    } | Format-Table -AutoSize | Out-String)
     Stop-LogGroup
 
     Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -204,17 +204,29 @@ function Build-PSModuleManifest {
     Write-Verbose '[CompatiblePSEditions]'
     $capturedPSEdition = $capturedPSEdition | Sort-Object -Unique
     if ($capturedPSEdition.count -eq 2) {
-        throw "A module cannot require both 'Desktop' and 'Core' editions."
+        throw @"
+Conflict detected:
+    The module requires both 'Desktop' and 'Core' editions.
+    'Desktop' and 'Core' editions cannot be required at the same time.
+"@
     }
     $manifest.CompatiblePSEditions = $capturedPSEdition.count -eq 0 ? @('Core', 'Desktop') : @($capturedPSEdition)
     $manifest.CompatiblePSEditions | ForEach-Object { Write-Verbose "[CompatiblePSEditions] - [$_]" }
 
     if ($manifest.PowerShellVersion -gt '5.1' -and $manifest.CompatiblePSEditions -contains 'Desktop') {
-        throw "[CompatiblePSEditions] - Cannot be PowerShellVersion > 5.1 and CompatiblePSEditions = 'Desktop'"
+        throw @'
+Conflict detected:
+    The module requires PowerShellVersion > 5.1 while CompatiblePSEditions = 'Desktop'
+    'Desktop' edition is not supported for PowerShellVersion > 5.1
+'@
     }
 
     if ($manifest.CompatiblePSEditions -contains 'Core' -and $manifest.PowerShellVersion -lt '6.0') {
-        throw "[CompatiblePSEditions] - Cannot be CompatiblePSEditions = 'Core' and PowerShellVersion < 6.0"
+        throw @'
+Conflict detected:
+    The module requires CompatiblePSEditions = 'Core' while PowerShellVersion < 6.0
+    'Core' edition is not supported for PowerShellVersion < 6.0
+'@
     }
 
     Write-Verbose '[PrivateData]'

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -204,10 +204,18 @@ function Build-PSModuleManifest {
     Write-Verbose '[CompatiblePSEditions]'
     $capturedPSEdition = $capturedPSEdition | Sort-Object -Unique
     if ($capturedPSEdition.count -eq 2) {
-        throw 'The module is requires both Desktop and Core editions.'
+        throw "A module cannot require both 'Desktop' and 'Core' editions."
     }
     $manifest.CompatiblePSEditions = $capturedPSEdition.count -eq 0 ? @('Core', 'Desktop') : @($capturedPSEdition)
     $manifest.CompatiblePSEditions | ForEach-Object { Write-Verbose "[CompatiblePSEditions] - [$_]" }
+
+    if ($manifest.PowerShellVersion -gt '5.1' -and $manifest.CompatiblePSEditions -contains 'Desktop') {
+        throw "[CompatiblePSEditions] - Cannot be PowerShellVersion > 5.1 and CompatiblePSEditions = 'Desktop'"
+    }
+
+    if ($manifest.CompatiblePSEditions -contains 'Core' -and $manifest.PowerShellVersion -lt '6.0') {
+        throw "[CompatiblePSEditions] - Cannot be CompatiblePSEditions = 'Core' and PowerShellVersion < 6.0"
+    }
 
     Write-Verbose '[PrivateData]'
     $privateData = $manifest.Keys -contains 'PrivateData' ? $null -ne $manifest.PrivateData ? $manifest.PrivateData : @{} : @{}

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -338,17 +338,14 @@ Conflict detected:
     #endregion Build manifest file
 
     #region Format manifest file
-    Start-LogGroup 'Format manifest file - Before format'
+    Start-LogGroup 'Build manifest file - Result - Before format'
     Show-FileContent -Path $outputManifestPath
     Stop-LogGroup
 
-    Start-LogGroup 'Format manifest file - After'
+    Start-LogGroup 'Build manifest file - Result - After format'
     Set-ModuleManifest -Path $outputManifestPath
     Show-FileContent -Path $outputManifestPath
     Stop-LogGroup
 
-    Start-LogGroup 'Format manifest file - Result'
-    Show-FileContent -Path $outputManifestPath
-    Stop-LogGroup
     #endregion Format manifest file
 }

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -197,7 +197,7 @@ function Build-PSModuleManifest {
     Write-Verbose '[PowerShellVersion]'
     $capturedVersions = $capturedVersions | Sort-Object -Unique -Descending
     $capturedVersions | ForEach-Object { Write-Verbose "[PowerShellVersion] - [$_]" }
-    $manifest.PowerShellVersion = $capturedVersions.count -eq 0 ? [version]'7.0' : [version]($capturedVersions | Select-Object -First 1)
+    $manifest.PowerShellVersion = $capturedVersions.count -eq 0 ? [version]'5.1' : [version]($capturedVersions | Select-Object -First 1)
     Write-Verbose '[PowerShellVersion] - Selecting version'
     Write-Verbose "[PowerShellVersion] - [$($manifest.PowerShellVersion)]"
 

--- a/scripts/helpers/Build/Build-PSModuleRootModule.ps1
+++ b/scripts/helpers/Build/Build-PSModuleRootModule.ps1
@@ -150,23 +150,23 @@ Export-ModuleMember @exports
     #endregion Build root module
 
     #region Format root module
-    Start-LogGroup 'Build root module - Format root module - Before format'
+    Start-LogGroup 'Build root module - Result - Before format'
     Show-FileContent -Path $rootModuleFile
     Stop-LogGroup
 
-    Start-LogGroup 'Build root module - Format root module - Format'
+    Start-LogGroup 'Build root module - Format'
     $AllContent = Get-Content -Path $rootModuleFile -Raw
     $settings = (Join-Path -Path $PSScriptRoot 'PSScriptAnalyzer.Tests.psd1')
     Invoke-Formatter -ScriptDefinition $AllContent -Settings $settings |
         Out-File -FilePath $rootModuleFile -Encoding utf8BOM -Force
     Stop-LogGroup
 
-    Start-LogGroup 'Build root module - Format root module - Result'
+    Start-LogGroup 'Build root module - Result - After format'
     Show-FileContent -Path $rootModuleFile
     Stop-LogGroup
     #endregion Format root module
 
-    Start-LogGroup 'Build root module - Result'
+    Start-LogGroup 'Build module - Result - File list'
     (Get-ChildItem -Path $ModuleOutputFolder -Recurse -Force).FullName | Sort-Object
     Stop-LogGroup
 }


### PR DESCRIPTION
## Description

- Default `PowerShellVersion` set to '5.1'.
- Add checks for `CompatiblePSVersion` and `PowerShellVersion`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
