### PR TITLE
🩹 [Patch]: Load the module from PR when overlaps

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -34,7 +34,7 @@ function Build-PSModuleManifest {
 
     $rootModule = Get-PSModuleRootModule -SourceFolderPath $ModuleOutputFolder
     $manifest.RootModule = $rootModule
-    $manifest.ModuleVersion = '0.0.1'
+    $manifest.ModuleVersion = '999.0.0'
 
     $manifest.Author = $manifest.Keys -contains 'Author' ? ($manifest.Author | IsNotNullOrEmpty) ? $manifest.Author : $env:GITHUB_REPOSITORY_OWNER : $env:GITHUB_REPOSITORY_OWNER
     Write-Verbose "[Author] - [$($manifest.Author)]"

--- a/scripts/helpers/Build/Import-PSModule.ps1
+++ b/scripts/helpers/Build/Import-PSModule.ps1
@@ -30,8 +30,10 @@
     $manifestFile = Get-ModuleManifest -Path $manifestFilePath -As FileInfo -Verbose
 
     Write-Verbose "Manifest file path: [$($manifestFile.FullName)]" -Verbose
+    Remove-Module -Name $ModuleName -Force
+    Uninstall-PSResource -Name $ModuleName -Force -SkipDependencyCheck
     Resolve-PSModuleDependencies -ManifestFilePath $manifestFile
-    Import-Module $ModuleName
+    Import-Module -Name $ModuleName -RequiredVersion '999.0.0'
 
     Write-Verbose 'List loaded modules'
     $availableModules = Get-Module -ListAvailable -Refresh -Verbose:$false

--- a/scripts/helpers/Build/Import-PSModule.ps1
+++ b/scripts/helpers/Build/Import-PSModule.ps1
@@ -30,8 +30,8 @@
     $manifestFile = Get-ModuleManifest -Path $manifestFilePath -As FileInfo -Verbose
 
     Write-Verbose "Manifest file path: [$($manifestFile.FullName)]" -Verbose
-    Remove-Module -Name $ModuleName -Force
-    Uninstall-PSResource -Name $ModuleName -Force -SkipDependencyCheck
+    Get-Module -Name $ModuleName -ListAvailable | Remove-Module -Force -Verbose:$false
+    Get-InstalledPSResource -Name $ModuleName | Uninstall-PSResource -Force -SkipDependencyCheck -Verbose:$false
     Resolve-PSModuleDependencies -ManifestFilePath $manifestFile
     Import-Module -Name $ModuleName -RequiredVersion '999.0.0'
 

--- a/scripts/helpers/Build/Import-PSModule.ps1
+++ b/scripts/helpers/Build/Import-PSModule.ps1
@@ -31,7 +31,7 @@
 
     Write-Verbose "Manifest file path: [$($manifestFile.FullName)]" -Verbose
     Get-Module -Name $ModuleName -ListAvailable | Remove-Module -Force -Verbose:$false
-    Get-InstalledPSResource -Name $ModuleName | Uninstall-PSResource -SkipDependencyCheck -Verbose:$false
+    Get-InstalledPSResource | Where-Object Name -EQ $ModuleName | Uninstall-PSResource -SkipDependencyCheck -Verbose:$false
     Resolve-PSModuleDependencies -ManifestFilePath $manifestFile
     Import-Module -Name $ModuleName -RequiredVersion '999.0.0'
 

--- a/scripts/helpers/Build/Import-PSModule.ps1
+++ b/scripts/helpers/Build/Import-PSModule.ps1
@@ -31,7 +31,7 @@
 
     Write-Verbose "Manifest file path: [$($manifestFile.FullName)]" -Verbose
     Get-Module -Name $ModuleName -ListAvailable | Remove-Module -Force -Verbose:$false
-    Get-InstalledPSResource -Name $ModuleName | Uninstall-PSResource -Force -SkipDependencyCheck -Verbose:$false
+    Get-InstalledPSResource -Name $ModuleName | Uninstall-PSResource -SkipDependencyCheck -Verbose:$false
     Resolve-PSModuleDependencies -ManifestFilePath $manifestFile
     Import-Module -Name $ModuleName -RequiredVersion '999.0.0'
 


### PR DESCRIPTION
## Description

- Load the module from the PR if its a framework dependency.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
