### PR TITLE
🪲 [Fix]: Manifest loading files from `init and `classes`

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -74,7 +74,7 @@ function Build-PSModuleManifest {
     $files = $ModuleOutputFolder | Get-ChildItem -File -ErrorAction SilentlyContinue | Where-Object -Property Name -NotLike '*.ps1'
     $files += $ModuleOutputFolder | Get-ChildItem -Directory | Get-ChildItem -Recurse -File -ErrorAction SilentlyContinue
     $files = $files | Select-Object -ExpandProperty FullName | ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart($pathSeparator) }
-    $fileList = $files | Where-Object { $_ -notLike 'public*' -and $_ -notLike 'private*' }
+    $fileList = $files | Where-Object { $_ -NotLike 'init*' -and $_ -NotLike 'classes*' -and $_ -NotLike 'public*' -and $_ -NotLike 'private*' }
     $manifest.FileList = $fileList.count -eq 0 ? @() : @($fileList)
     $manifest.FileList | ForEach-Object { Write-Verbose "[FileList] - [$_]" }
 

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -95,7 +95,7 @@ function Build-PSModuleManifest {
     $manifest.NestedModules | ForEach-Object { Write-Verbose "[NestedModules] - [$_]" }
 
     Write-Verbose '[ScriptsToProcess]'
-    $allScriptsToProcess = @('scripts', 'classes') | ForEach-Object {
+    $allScriptsToProcess = @('scripts') | ForEach-Object {
         Write-Verbose "[ScriptsToProcess] - Processing [$_]"
         $scriptsFolderPath = Join-Path $ModuleOutputFolder $_
         $scriptsToProcess = Get-ChildItem -Path $scriptsFolderPath -Recurse -File -ErrorAction SilentlyContinue -Include '*.ps1' |

--- a/scripts/helpers/Build/Build-PSModuleRootModule.ps1
+++ b/scripts/helpers/Build/Build-PSModuleRootModule.ps1
@@ -96,6 +96,8 @@ Write-Verbose "[$scriptName] - [data] - Done"
 
     #region - Add content from subfolders
     $scriptFoldersToProcess = @(
+        'init',
+        'classes',
         'private',
         'public'
     )


### PR DESCRIPTION
## Description

- Fix an issue where manifest filelist contains files from `init and `classes`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
