### PR TITLE
🪲 [Fix] Tags into array, instead of concatenated string

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -244,17 +244,18 @@ function Build-PSModuleManifest {
     } catch {
         $repoLabels = @()
     }
-    $manifestTags = @()
-    $manifestTags = $PSData.Keys -contains 'Tags' ? ($PSData.Tags).Count -gt 0 ? $PSData.Tags : $repoLabels : $repoLabels
+    $manifestTags = [Collections.Generic.List[string]]::new()
+    $tags = $PSData.Keys -contains 'Tags' ? ($PSData.Tags).Count -gt 0 ? $PSData.Tags : $repoLabels : $repoLabels
+    $tags | ForEach-Object { $manifestTags.Add($_) }
     # Add tags for compatability mode. https://docs.microsoft.com/en-us/powershell/scripting/developer/module/how-to-write-a-powershell-module-manifest?view=powershell-7.1#compatibility-tags
     if ($manifest.CompatiblePSEditions -contains 'Desktop') {
         if ($manifestTags -notcontains 'PSEdition_Desktop') {
-            $manifestTags += 'PSEdition_Desktop'
+            $manifestTags.Add('PSEdition_Desktop')
         }
     }
     if ($manifest.CompatiblePSEditions -contains 'Core') {
         if ($manifestTags -notcontains 'PSEdition_Core') {
-            $manifestTags += 'PSEdition_Core'
+            $manifestTags.Add('PSEdition_Core')
         }
     }
     $manifestTags | ForEach-Object { Write-Verbose "[Tags] - [$_]" }


### PR DESCRIPTION
## Description

- Fix an issue where tags would be concatenated in a string, instead of a array of strings.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
