### PR TITLE
🩹 [Patch]: Remove escaping of special markdown compliant characters

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -50,9 +50,9 @@ function Build-PSModuleDocumentation {
     }
     Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
         $content = Get-Content -Path $_.FullName -Raw
-        $content = $content -replace "\``", "``"
-        $content = $content -replace '\[', '['
-        $content = $content -replace '\]', ']'
+        $content = $content -replace "\\``", "``"
+        $content = $content -replace '\\[', '['
+        $content = $content -replace '\\]', ']'
         $content | Set-Content -Path $_.FullName
     }
     Stop-LogGroup

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -41,12 +41,19 @@ function Build-PSModuleDocumentation {
                 $fixedOpening = $true
             } elseif ($line -match '^```.+$') {
                 $fixedOpening = $true
-            } elseif ($line -match '^```$'){
+            } elseif ($line -match '^```$') {
                 $fixedOpening = $false
             }
             $newContent += $line
         }
         $newContent | Set-Content -Path $_.FullName
+    }
+    Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
+        $content = Get-Content -Path $_.FullName
+        $content = $content -replace "\``", "``"
+        $content = $content -replace '\[', '['
+        $content = $content -replace '\]', ']'
+        $content | Set-Content -Path $_.FullName
     }
     Stop-LogGroup
 

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -50,9 +50,9 @@ function Build-PSModuleDocumentation {
     }
     Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
         $content = Get-Content -Path $_.FullName -Raw
-        $content = $content -replace "\\``", "``"
-        $content = $content -replace '\\[', '['
-        $content = $content -replace '\\]', ']'
+        $content = $content -replace '\\`', '`'
+        $content = $content -replace '\\\[', '['
+        $content = $content -replace '\\\]', ']'
         $content | Set-Content -Path $_.FullName
     }
     Stop-LogGroup

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -49,7 +49,7 @@ function Build-PSModuleDocumentation {
         $newContent | Set-Content -Path $_.FullName
     }
     Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
-        $content = Get-Content -Path $_.FullName
+        $content = Get-Content -Path $_.FullName -Raw
         $content = $content -replace "\``", "``"
         $content = $content -replace '\[', '['
         $content = $content -replace '\]', ']'
@@ -60,7 +60,7 @@ function Build-PSModuleDocumentation {
     Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
         $fileName = $_.Name
         $hash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash
-        Start-LogGroup "- File: [$fileName] - [$hash]"
+        Start-LogGroup " - [$fileName] - [$hash]"
         Show-FileContent -Path $_
         Stop-LogGroup
     }

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -53,6 +53,9 @@ function Build-PSModuleDocumentation {
         $content = $content -replace '\\`', '`'
         $content = $content -replace '\\\[', '['
         $content = $content -replace '\\\]', ']'
+        $content = $content -replace '\\\<', '<'
+        $content = $content -replace '\\\>', '>'
+        $content = $content -replace '\\\\', '\'
         $content | Set-Content -Path $_.FullName
     }
     Stop-LogGroup

--- a/tests/src/PSModuleTest/public/New-PSModuleTest.ps1
+++ b/tests/src/PSModuleTest/public/New-PSModuleTest.ps1
@@ -12,6 +12,8 @@ function New-PSModuleTest {
 
         .NOTES
         Testing if a module can have a [Markdown based link](https://example.com).
+        !"#¤%&/()=?`´^¨*'-_+§½{[]}<>|@£$€¥¢:;.,"
+        \[This is a test\]
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',

--- a/tests/src/PSModuleTest/public/New-PSModuleTest.ps1
+++ b/tests/src/PSModuleTest/public/New-PSModuleTest.ps1
@@ -9,6 +9,9 @@ function New-PSModuleTest {
         Test-PSModule -Name 'World'
 
         "Hello, World!"
+
+        .NOTES
+        Testing if a module can have a [Markdown based link](https://example.com).
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',


### PR DESCRIPTION
## Description

- Remove escaping (\) of special characters in doc files that are compliant with markdown formatting:
  - '`'
  - '['
  - ']'
  - '<'
  - '>'
  - '\\'

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
