### PR TITLE
🪲 [Fix]: Load only the built module for doc creation

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules platyPS, Utilities
+﻿#Requires -Modules Microsoft.PowerShell.PlatyPS, Utilities
 
 function Build-PSModuleDocumentation {
     <#
@@ -28,7 +28,9 @@ function Build-PSModuleDocumentation {
     )
 
     LogGroup 'Build docs - Generate markdown help' {
-        $null = New-MarkdownHelp -Module $ModuleName -OutputFolder $DocsOutputFolder -Force -Verbose
+        $moduleInfo = Get-Module -Name $ModuleName | Where-Object { $_.Version -eq '999.0.0' }
+        Write-Verbose ($moduleInfo | Out-String)
+        $null = New-MarkdownCommandHelp -ModuleInfo $moduleInfo -OutputFolder $DocsOutputFolder -Force
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $content = Get-Content -Path $_.FullName
             $fixedOpening = $false

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -31,11 +31,13 @@ function Build-PSModuleDocumentation {
         $moduleInfo = Get-Module -Name $ModuleName | Where-Object { $_.Version -eq '999.0.0' }
         Write-Verbose ($moduleInfo | Out-String)
         try {
-            New-MarkdownCommandHelp -ModuleInfo $moduleInfo -OutputFolder $DocsOutputFolder -Force
+            New-MarkdownCommandHelp -ModuleInfo $moduleInfo -OutputFolder $DocsOutputFolder -Force -ErrorAction 'Continue'
         } catch {
+            Get-Error | Select-Object *
             Write-Error $_
             throw "Failed to generate markdown help for module [$ModuleName]."
         }
+        # $null = New-MarkdownHelp -Module $ModuleName -OutputFolder $DocsOutputFolder -Force -Verbose
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $content = Get-Content -Path $_.FullName
             $fixedOpening = $false

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -30,7 +30,12 @@ function Build-PSModuleDocumentation {
     LogGroup 'Build docs - Generate markdown help' {
         $moduleInfo = Get-Module -Name $ModuleName | Where-Object { $_.Version -eq '999.0.0' }
         Write-Verbose ($moduleInfo | Out-String)
-        $null = New-MarkdownCommandHelp -ModuleInfo $moduleInfo -OutputFolder $DocsOutputFolder -Force
+        try {
+            New-MarkdownCommandHelp -ModuleInfo $moduleInfo -OutputFolder $DocsOutputFolder -Force
+        } catch {
+            Write-Error $_
+            throw "Failed to generate markdown help for module [$ModuleName]."
+        }
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $content = Get-Content -Path $_.FullName
             $fixedOpening = $false

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -28,16 +28,10 @@ function Build-PSModuleDocumentation {
     )
 
     LogGroup 'Build docs - Generate markdown help' {
-        $moduleInfo = Get-Module -Name $ModuleName | Where-Object { $_.Version -eq '999.0.0' }
-        Write-Verbose ($moduleInfo | Out-String)
-        try {
-            New-MarkdownCommandHelp -ModuleInfo $moduleInfo -OutputFolder $DocsOutputFolder -Force -ErrorAction 'Continue'
-        } catch {
-            Get-Error | Select-Object *
-            Write-Error $_
-            throw "Failed to generate markdown help for module [$ModuleName]."
-        }
-        # $null = New-MarkdownHelp -Module $ModuleName -OutputFolder $DocsOutputFolder -Force -Verbose
+        $ModuleName | Remove-Module -Force
+        Import-Module -Name $ModuleName -Force -RequiredVersion '999.0.0'
+        Write-Verbose ($module | Get-Module)
+        $null = New-MarkdownHelp -Module $ModuleName -OutputFolder $DocsOutputFolder -Force -Verbose
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $content = Get-Content -Path $_.FullName
             $fixedOpening = $false

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules Microsoft.PowerShell.PlatyPS, Utilities
+﻿#Requires -Modules platyPS, Utilities
 
 function Build-PSModuleDocumentation {
     <#

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -30,7 +30,7 @@ function Build-PSModuleDocumentation {
     LogGroup 'Build docs - Generate markdown help' {
         $ModuleName | Remove-Module -Force
         Import-Module -Name $ModuleName -Force -RequiredVersion '999.0.0'
-        Write-Verbose ($module | Get-Module)
+        Write-Verbose ($ModuleName | Get-Module)
         $null = New-MarkdownHelp -Module $ModuleName -OutputFolder $DocsOutputFolder -Force -Verbose
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $content = Get-Content -Path $_.FullName


### PR DESCRIPTION
## Description

- Fix an issue where the doc generation script was loading the module twice, causing errors.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
