### PR TITLE
🩹 [Patch]: Adds a module variable called `$script:PSModuleInfo`

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleRootModule.ps1
+++ b/scripts/helpers/Build/Build-PSModuleRootModule.ps1
@@ -135,12 +135,15 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
             Add-Content -Path $rootModuleFile -Force -Value @'
 [CmdletBinding()]
 param()
+'@
+        }
 
+        # Add a variable $script:PSModuleInfo to the root module, which contains the module manifest information.
+        Add-Content -Path $rootModuleFile -Force -Value @'
 $baseName = [System.IO.Path]::GetFileNameWithoutExtension($PSCommandPath)
 $script:PSModuleInfo = Test-ModuleManifest -Path "$PSScriptRoot\$baseName.psd1"
 $script:PSModuleInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
 '@
-        }
         #endregion - Module header
 
         #region - Module post-header

--- a/scripts/helpers/Build/Build-PSModuleRootModule.ps1
+++ b/scripts/helpers/Build/Build-PSModuleRootModule.ps1
@@ -135,6 +135,10 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
             Add-Content -Path $rootModuleFile -Force -Value @'
 [CmdletBinding()]
 param()
+
+$baseName = [System.IO.Path]::GetFileNameWithoutExtension($PSCommandPath)
+$script:PSModuleInfo = Test-ModuleManifest -Path "$PSScriptRoot\$baseName.psd1"
+$script:PSModuleInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
 '@
         }
         #endregion - Module header


### PR DESCRIPTION
## Description

- Adds a module variable called `$script:PSModuleInfo` with contents from the module manifest. Loaded via `Test-ModuleManifest`.
  - Fixes #71 
- Prints the contents of `$script:PSModuleInfo` with `-Debug` flag.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
