### PR TITLE
🪲 [Fix]: Moving docs one level out (not in a `$ModuleName` folder)

### DIFF
--- a/scripts/helpers/Build-PSModule.ps1
+++ b/scripts/helpers/Build-PSModule.ps1
@@ -43,7 +43,7 @@ function Build-PSModule {
         $moduleOutputFolder = New-Item -Path $ModulesOutputFolderPath -Name $ModuleName -ItemType Directory -Force
         Write-Verbose "Module output folder: [$moduleOutputFolder]"
 
-        $docsOutputFolder = New-Item -Path $DocsOutputFolderPath -Name $ModuleName -ItemType Directory -Force
+        $docsOutputFolder = New-Item -Path $DocsOutputFolderPath -ItemType Directory -Force
         Write-Verbose "Docs output folder:   [$docsOutputFolder]"
     }
 
@@ -51,7 +51,7 @@ function Build-PSModule {
     Build-PSModuleManifest -ModuleName $ModuleName -ModuleOutputFolder $moduleOutputFolder
     Build-PSModuleRootModule -ModuleName $ModuleName -ModuleOutputFolder $moduleOutputFolder
     Update-PSModuleManifestAliasesToExport -ModuleName $ModuleName -ModuleOutputFolder $moduleOutputFolder
-    Build-PSModuleDocumentation -ModuleName $ModuleName -ModuleSourceFolder $moduleSourceFolder -DocsOutputFolder $DocsOutputFolderPath
+    Build-PSModuleDocumentation -ModuleName $ModuleName -ModuleSourceFolder $moduleSourceFolder -DocsOutputFolder $docsOutputFolder
 
     LogGroup 'Build manifest file - Final Result' {
         $outputManifestPath = Join-Path -Path $ModuleOutputFolder -ChildPath "$ModuleName.psd1"

--- a/scripts/helpers/Build-PSModule.ps1
+++ b/scripts/helpers/Build-PSModule.ps1
@@ -51,7 +51,7 @@ function Build-PSModule {
     Build-PSModuleManifest -ModuleName $ModuleName -ModuleOutputFolder $moduleOutputFolder
     Build-PSModuleRootModule -ModuleName $ModuleName -ModuleOutputFolder $moduleOutputFolder
     Update-PSModuleManifestAliasesToExport -ModuleName $ModuleName -ModuleOutputFolder $moduleOutputFolder
-    Build-PSModuleDocumentation -ModuleName $ModuleName -ModuleSourceFolder $moduleSourceFolder -DocsOutputFolder $docsOutputFolder
+    Build-PSModuleDocumentation -ModuleName $ModuleName -ModuleSourceFolder $moduleSourceFolder -DocsOutputFolder $DocsOutputFolderPath
 
     LogGroup 'Build manifest file - Final Result' {
         $outputManifestPath = Join-Path -Path $ModuleOutputFolder -ChildPath "$ModuleName.psd1"

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -72,8 +72,6 @@ function Build-PSModuleDocumentation {
     }
 
     LogGroup 'Build docs - Structure markdown files to match source files' {
-        $tmpDocsFolderPath = Split-Path -Path $DocsOutputFolder.FullName -Parent
-        Move-Item -Path $DocsOutputFolder -Destination $tmpDocsFolderPath -Force
         $PublicFunctionsFolder = Join-Path $ModuleSourceFolder.FullName 'functions\public' | Get-Item
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $file = $_

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -71,29 +71,28 @@ function Build-PSModuleDocumentation {
         }
     }
 
-    # Markdown files are called the same as the source files, but with a .md extension.
-    # They are all located flat in the docsoutputfolder.
-    # I want the markdown files to be moved in the same folder structure as the source files.
     LogGroup 'Build docs - Structure markdown files to match source files' {
-        $PublicFunctions = Join-Path $ModuleSourceFolder.FullName 'functions\public' | Get-Item
+        $tmpDocsFolderPath = Join-Path -Path $DocsOutputFolder -ChildPath $ModuleName
+        Move-Item -Path $tmpDocsFolderPath -Destination $DocsOutputFolder -Force
+        $PublicFunctionsFolder = Join-Path $ModuleSourceFolder.FullName 'functions\public' | Get-Item
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $file = $_
             Write-Verbose "Processing:        $file"
 
             # find the source code file that matches the markdown file
-            $scriptPath = Get-ChildItem -Path $PublicFunctions -Recurse -Force | Where-Object { $_.Name -eq ($file.BaseName + '.ps1') }
+            $scriptPath = Get-ChildItem -Path $PublicFunctionsFolder -Recurse -Force | Where-Object { $_.Name -eq ($file.BaseName + '.ps1') }
             Write-Verbose "Found script path: $scriptPath"
-            $docsFilePath = ($scriptPath.FullName).Replace($PublicFunctions.FullName, $DocsOutputFolder.FullName).Replace('.ps1', '.md')
+            $docsFilePath = ($scriptPath.FullName).Replace($PublicFunctionsFolder.FullName, $DocsOutputFolder.FullName).Replace('.ps1', '.md')
             Write-Verbose "Doc file path:     $docsFilePath"
             $docsFolderPath = Split-Path -Path $docsFilePath -Parent
             New-Item -Path $docsFolderPath -ItemType Directory -Force
             Move-Item -Path $file.FullName -Destination $docsFilePath -Force
         }
         # Get the MD files that are in the public functions folder and move them to the same place in the docs folder
-        Get-ChildItem -Path $PublicFunctions -Recurse -Force -Include '*.md' | ForEach-Object {
+        Get-ChildItem -Path $PublicFunctionsFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $file = $_
             Write-Verbose "Processing:        $file"
-            $docsFilePath = ($file.FullName).Replace($PublicFunctions.FullName, $DocsOutputFolder.FullName)
+            $docsFilePath = ($file.FullName).Replace($PublicFunctionsFolder.FullName, $DocsOutputFolder.FullName)
             Write-Verbose "Doc file path:     $docsFilePath"
             $docsFolderPath = Split-Path -Path $docsFilePath -Parent
             New-Item -Path $docsFolderPath -ItemType Directory -Force

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -73,7 +73,7 @@ function Build-PSModuleDocumentation {
 
     LogGroup 'Build docs - Structure markdown files to match source files' {
         $tmpDocsFolderPath = Split-Path -Path $DocsOutputFolder.FullName -Parent
-        Move-Item -Path $tmpDocsFolderPath -Destination $tmpDocsFolderPath -Force
+        Move-Item -Path $DocsOutputFolder -Destination $tmpDocsFolderPath -Force
         $PublicFunctionsFolder = Join-Path $ModuleSourceFolder.FullName 'functions\public' | Get-Item
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $file = $_

--- a/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
+++ b/scripts/helpers/Build/Build-PSModuleDocumentation.ps1
@@ -72,8 +72,8 @@ function Build-PSModuleDocumentation {
     }
 
     LogGroup 'Build docs - Structure markdown files to match source files' {
-        $tmpDocsFolderPath = Join-Path -Path $DocsOutputFolder -ChildPath $ModuleName
-        Move-Item -Path $tmpDocsFolderPath -Destination $DocsOutputFolder -Force
+        $tmpDocsFolderPath = Split-Path -Path $DocsOutputFolder.FullName -Parent
+        Move-Item -Path $tmpDocsFolderPath -Destination $tmpDocsFolderPath -Force
         $PublicFunctionsFolder = Join-Path $ModuleSourceFolder.FullName 'functions\public' | Get-Item
         Get-ChildItem -Path $DocsOutputFolder -Recurse -Force -Include '*.md' | ForEach-Object {
             $file = $_


### PR DESCRIPTION
## Description

- Moving docs one level out (not in a `$ModuleName` folder)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
