### PR TITLE
🩹 [Patch]: Remove other modules before reimporting reqs for processed module

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleRootModule.ps1
+++ b/scripts/helpers/Build/Build-PSModuleRootModule.ps1
@@ -36,6 +36,10 @@ function Build-PSModuleRootModule {
         'PSReviewUnusedParameter', '', Scope = 'Function',
         Justification = 'LogGroup - Scoping affects the variables line of sight.'
     )]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSAvoidUsingWriteHost', '', Scope = 'Function',
+        Justification = 'Want to just write to the console, not the pipeline.'
+    )]
     param(
         # Name of the module.
         [Parameter(Mandatory)]
@@ -241,9 +245,9 @@ Export-ModuleMember @exports
 
     }
 
-    # LogGroup 'Build root module - Result - Before format' {
-    #     Show-FileContent -Path $rootModuleFile
-    # }
+    LogGroup 'Build root module - Result - Before format' {
+        Write-Host (Show-FileContent -Path $rootModuleFile)
+    }
 
     LogGroup 'Build root module - Format' {
         $AllContent = Get-Content -Path $rootModuleFile -Raw
@@ -252,9 +256,9 @@ Export-ModuleMember @exports
             Out-File -FilePath $rootModuleFile -Encoding utf8BOM -Force
     }
 
-    # LogGroup 'Build root module - Result - After format' {
-    #     Show-FileContent -Path $rootModuleFile
-    # }
+    LogGroup 'Build root module - Result - After format' {
+        Write-Host (Show-FileContent -Path $rootModuleFile)
+    }
 
     LogGroup 'Build root module - Validate - Import' {
         Add-PSModulePath -Path (Split-Path -Path $ModuleOutputFolder -Parent)

--- a/scripts/helpers/Build/Build-PSModuleRootModule.ps1
+++ b/scripts/helpers/Build/Build-PSModuleRootModule.ps1
@@ -241,9 +241,9 @@ Export-ModuleMember @exports
 
     }
 
-    LogGroup 'Build root module - Result - Before format' {
-        Show-FileContent -Path $rootModuleFile
-    }
+    # LogGroup 'Build root module - Result - Before format' {
+    #     Show-FileContent -Path $rootModuleFile
+    # }
 
     LogGroup 'Build root module - Format' {
         $AllContent = Get-Content -Path $rootModuleFile -Raw
@@ -252,9 +252,9 @@ Export-ModuleMember @exports
             Out-File -FilePath $rootModuleFile -Encoding utf8BOM -Force
     }
 
-    LogGroup 'Build root module - Result - After format' {
-        Show-FileContent -Path $rootModuleFile
-    }
+    # LogGroup 'Build root module - Result - After format' {
+    #     Show-FileContent -Path $rootModuleFile
+    # }
 
     LogGroup 'Build root module - Validate - Import' {
         Add-PSModulePath -Path (Split-Path -Path $ModuleOutputFolder -Parent)

--- a/scripts/helpers/Build/Import-PSModule.ps1
+++ b/scripts/helpers/Build/Import-PSModule.ps1
@@ -30,8 +30,8 @@
     Write-Verbose "Manifest file path: [$($manifestFile.FullName)]" -Verbose
     $existingModule = Get-Module -Name $ModuleName -ListAvailable
     $existingModule | Remove-Module -Force -Verbose
-    $existingModule.RequiredModules | Remove-Module -Force -Verbose
-    $existingModule.NestedModules | Remove-Module -Force -Verbose
+    $existingModule.RequiredModules | ForEach-Object { Remove-Module -Name $_ -Force -Verbose }
+    $existingModule.NestedModules | ForEach-Object { Remove-Module -Name $_ -Force -Verbose }
     # Get-InstalledPSResource | Where-Object Name -EQ $ModuleName | Uninstall-PSResource -SkipDependencyCheck -Verbose:$false
     Resolve-PSModuleDependencies -ManifestFilePath $manifestFile
     Import-Module -Name $ModuleName -RequiredVersion '999.0.0'

--- a/scripts/helpers/Build/Import-PSModule.ps1
+++ b/scripts/helpers/Build/Import-PSModule.ps1
@@ -28,7 +28,10 @@
     $manifestFile = Get-ModuleManifest -Path $manifestFilePath -As FileInfo -Verbose
 
     Write-Verbose "Manifest file path: [$($manifestFile.FullName)]" -Verbose
-    Get-Module -Name $ModuleName -ListAvailable | Remove-Module -Force -Verbose:$false
+    $existingModule = Get-Module -Name $ModuleName -ListAvailable
+    $existingModule | Remove-Module -Force -Verbose:$false
+    $existingModule.RequiredModules | Remove-Module -Force -Verbose:$false
+    $existingModule.NestedModules | Remove-Module -Force -Verbose:$false
     # Get-InstalledPSResource | Where-Object Name -EQ $ModuleName | Uninstall-PSResource -SkipDependencyCheck -Verbose:$false
     Resolve-PSModuleDependencies -ManifestFilePath $manifestFile
     Import-Module -Name $ModuleName -RequiredVersion '999.0.0'

--- a/scripts/helpers/Build/Import-PSModule.ps1
+++ b/scripts/helpers/Build/Import-PSModule.ps1
@@ -29,9 +29,9 @@
 
     Write-Verbose "Manifest file path: [$($manifestFile.FullName)]" -Verbose
     $existingModule = Get-Module -Name $ModuleName -ListAvailable
-    $existingModule | Remove-Module -Force -Verbose:$false
-    $existingModule.RequiredModules | Remove-Module -Force -Verbose:$false
-    $existingModule.NestedModules | Remove-Module -Force -Verbose:$false
+    $existingModule | Remove-Module -Force -Verbose
+    $existingModule.RequiredModules | Remove-Module -Force -Verbose
+    $existingModule.NestedModules | Remove-Module -Force -Verbose
     # Get-InstalledPSResource | Where-Object Name -EQ $ModuleName | Uninstall-PSResource -SkipDependencyCheck -Verbose:$false
     Resolve-PSModuleDependencies -ManifestFilePath $manifestFile
     Import-Module -Name $ModuleName -RequiredVersion '999.0.0'


### PR DESCRIPTION
## Description


This pull request includes changes to the `scripts/helpers/Build` directory, focusing on improving the handling of module outputs and dependencies. The most important changes are as follows:

Improvements to module output handling:

* [`scripts/helpers/Build/Build-PSModuleRootModule.ps1`](diffhunk://#diff-1d337ff39f37506a54fda1c5d0487f1b2c2ef318f216a4d9a56c3e7248b69879R39-R42): Suppressed the 'PSAvoidUsingWriteHost' warning to allow direct console output instead of writing to the pipeline.
* [`scripts/helpers/Build/Build-PSModuleRootModule.ps1`](diffhunk://#diff-1d337ff39f37506a54fda1c5d0487f1b2c2ef318f216a4d9a56c3e7248b69879L245-R249): Changed `Show-FileContent` calls to use `Write-Host` for direct console output in the 'Build root module - Result' sections. [[1]](diffhunk://#diff-1d337ff39f37506a54fda1c5d0487f1b2c2ef318f216a4d9a56c3e7248b69879L245-R249) [[2]](diffhunk://#diff-1d337ff39f37506a54fda1c5d0487f1b2c2ef318f216a4d9a56c3e7248b69879L256-R260)

Enhancements to module dependency handling:

* [`scripts/helpers/Build/Import-PSModule.ps1`](diffhunk://#diff-15f2301e39f56f54fa469db56cc7c487e2df36eb295bb74e8d2325aabcd164c0L31-R34): Added logic to remove required and nested modules of an existing module before re-importing it, ensuring a clean state.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
