### PR TITLE
🩹 [Patch]: Add Retry on Install-Module

### DIFF
--- a/scripts/helpers/Build/Resolve-PSModuleDependency.ps1
+++ b/scripts/helpers/Build/Resolve-PSModuleDependency.ps1
@@ -1,4 +1,6 @@
-﻿function Resolve-PSModuleDependency {
+﻿#Requires -Modules Retry
+
+function Resolve-PSModuleDependency {
     <#
         .SYNOPSIS
         Resolve dependencies for a module based on the manifest file.
@@ -47,7 +49,9 @@
         Write-Verbose "[$($installParams.Name)] - Installing module"
         $VerbosePreferenceOriginal = $VerbosePreference
         $VerbosePreference = 'SilentlyContinue'
-        Install-Module @installParams -AllowPrerelease:$false
+        Retry -Count 5 -Delay 10 {
+            Install-Module @installParams -AllowPrerelease:$false
+        }
         $VerbosePreference = $VerbosePreferenceOriginal
         Write-Verbose "[$($installParams.Name)] - Importing module"
         $VerbosePreferenceOriginal = $VerbosePreference

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,4 +1,4 @@
-﻿#REQUIRES -Modules Utilities
+﻿#Requires -Modules Utilities
 
 [CmdletBinding()]
 param()


### PR DESCRIPTION
## Description

This pull request includes several changes to the `scripts/helpers/Build/Resolve-PSModuleDependency.ps1` and `scripts/main.ps1` files to improve module dependency resolution and error handling.

### Improvements to module dependency resolution and error handling:

* [`scripts/helpers/Build/Resolve-PSModuleDependency.ps1`](diffhunk://#diff-b278dc96f784d462b15a4fe67b088a5b5d9cc502dd6eba3d660da085e576652fL1-R3): Added a requirement for the `Retry` module to handle retries during module installation.
* [`scripts/helpers/Build/Resolve-PSModuleDependency.ps1`](diffhunk://#diff-b278dc96f784d462b15a4fe67b088a5b5d9cc502dd6eba3d660da085e576652fR52-R54): Implemented retry logic with 5 retries and a 10-second delay for the `Install-Module` command to improve robustness against transient errors.

### Minor formatting changes:

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L1-R1): Fixed the casing of the `#Requires` directive for the `Utilities` module.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
