### PR TITLE
 🪲 [Fix]: Add copyright information to module manifest

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -63,10 +63,10 @@ function Build-PSModuleManifest {
         Write-Verbose "[CompanyName] - [$($manifest.CompanyName)]"
 
         $year = Get-Date -Format 'yyyy'
-        $copyRightOwner = $manifest.CompanyName -eq $manifest.Author ? $manifest.Author : "$($manifest.Author) | $($manifest.CompanyName)"
-        $copyRight = "(c) $year $copyRightOwner. All rights reserved."
-        $manifest.CopyRight = $manifest.Keys -contains 'CopyRight' ? -not [string]::IsNullOrEmpty($manifest.CopyRight) ? $manifest.CopyRight : $copyRight : $copyRight
-        Write-Verbose "[CopyRight] - [$($manifest.CopyRight)]"
+        $copyrightOwner = $manifest.CompanyName -eq $manifest.Author ? $manifest.Author : "$($manifest.Author) | $($manifest.CompanyName)"
+        $copyright = "(c) $year $copyrightOwner. All rights reserved."
+        $manifest.Copyright = $manifest.Keys -contains 'Copyright' ? -not [string]::IsNullOrEmpty($manifest.Copyright) ? $manifest.Copyright : $copyright : $copyright
+        Write-Verbose "[Copyright] - [$($manifest.Copyright)]"
 
         $repoDescription = gh repo view --json description | ConvertFrom-Json | Select-Object -ExpandProperty description
         $manifest.Description = $manifest.Keys -contains 'Description' ? ($manifest.Description | IsNotNullOrEmpty) ? $manifest.Description : $repoDescription : $repoDescription

--- a/tests/srcWithManifest/manifest.psd1
+++ b/tests/srcWithManifest/manifest.psd1
@@ -2,4 +2,5 @@
     ModuleVersion = '0.0.0'
     RootModule    = 'PSModuleTest.psm1'
     Copyright     = 'Test'
+    Description   = 'This is a test module.'
 }

--- a/tests/srcWithManifest/manifest.psd1
+++ b/tests/srcWithManifest/manifest.psd1
@@ -1,4 +1,5 @@
 @{
     ModuleVersion = '0.0.0'
     RootModule    = 'PSModuleTest.psm1'
+    CopyRight     = 'Test'
 }

--- a/tests/srcWithManifest/manifest.psd1
+++ b/tests/srcWithManifest/manifest.psd1
@@ -1,5 +1,5 @@
 @{
     ModuleVersion = '0.0.0'
     RootModule    = 'PSModuleTest.psm1'
-    CopyRight     = 'Test'
+    Copyright     = 'Test'
 }


### PR DESCRIPTION
## Description

This pull request includes changes to the `Build-PSModuleManifest.ps1` script and the `manifest.psd1` test file to correct a typo and add new properties.

- Fixes #86 
- Fixes #87 

Fixes and enhancements:

* [`scripts/helpers/Build/Build-PSModuleManifest.ps1`](diffhunk://#diff-50cfb011f5c8aeef8145003927ec3e5edfdf26e5d417bcee6e441517c07454f9L66-R69): Corrected casing on `CopyRight` to `Copyright` in multiple instances.

Test file updates:

* [`tests/srcWithManifest/manifest.psd1`](diffhunk://#diff-399c133608e76653ee44cfb1565529498f11aa4741e3ce9a5abc2e6a9b005554R4-R5): Added `Copyright` and `Description` properties to the manifest for testing purposes.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
