### PR TITLE
🩹 [Patch]: Allow more overrides from `manifest.psd1` + smarter defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ During the module manifest build process the following steps are performed:
 1. Set the `Description` based on the GitHub repository description. If a value exists in the source manifest file, this value is used.
 1. Set various properties in the manifest such as `PowerShellHostName`, `PowerShellHostVersion`, `DotNetFrameworkVersion`, `ClrVersion`, and `ProcessorArchitecture`. There is currently no automation for these properties. If a value exists in the source manifest file, this value is used.
 1. Get the list of files in the module source folder and set the `FileList` property in the manifest.
-1. Get the list of required assemblies (`*.dll` files) from the `assemblies` folder and set the `RequiredAssemblies` property in the manifest.
-1. Get the list of nested modules (`*.psm1` files) from the `modules` folder and set the `NestedModules` property in the manifest.
+1. Get the list of required assemblies (`*.dll` files) from the `assemblies` and `modules` (depth = 1) folder and set the `RequiredAssemblies` property in the manifest.
+1. Get the list of nested modules (`*.psm1`, `*.ps1` and `*.dll` files one level down) from the `modules` folder and set the `NestedModules` property in the manifest.
 1. Get the list of scripts to process (`*.ps1` files) from the `scripts` folders and set the `ScriptsToProcess` property in the manifest. This ensures that the scripts are loaded to the caller session (parent of module session).
 1. Get the list of types to process by searching for `*.Types.ps1xml` files in the entire module source folder and set the `TypesToProcess` property in the manifest.
 1. Get the list of formats to process by searching for `*.Format.ps1xml` files in the entire module source folder and set the `FormatsToProcess` property in the manifest.
@@ -120,11 +120,11 @@ Linking the description to the module manifest file might show more how this wor
     ClrVersion             = '' # Get from manifest file, null if not provided.
     ProcessorArchitecture  = '' # Get from manifest file, null if not provided.
     RequiredModules        = @() # Get from source files, REQUIRES -Modules <Module-Name> | <Hashtable> -> Need to be installed and loaded on build time. Will be installed in global session state during installtion.
-    RequiredAssemblies     = @() # Get from assemblies\*.dll.
+    RequiredAssemblies     = @() # Get from assemblies\*.dll + modules\*.dll.
     ScriptsToProcess       = @() # Get from scripts\*.ps1 and classes\*.ps1 ordered by name. These are loaded to the caller session (parent of module session).
     TypesToProcess         = @() # Get from *.Types.ps1xml anywhere in the source module folder.
     FormatsToProcess       = @() # Get from *.Format.ps1xml anywhere in the source module folder.
-    NestedModules          = @() # Get from modules\*.psm1.
+    NestedModules          = @() # Get from modules\*.psm1 + modules\*.ps1 + modules\*.dll.
     FunctionsToExport      = @() # Get from public\*.ps1.
     CmdletsToExport        = @() # Get from manifest file, @() if not provided.
     VariablesToExport      = @() # Get from variables\public\*.ps1.

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -116,7 +116,7 @@ function Build-PSModuleManifest {
         $requiredAssemblies = Get-ChildItem -Path $requiredAssembliesFolderPath -Recurse -File -ErrorAction SilentlyContinue -Filter '*.dll' |
             Select-Object -ExpandProperty FullName |
             ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart([System.IO.Path]::DirectorySeparatorChar) }
-        $requiredAssemblies += Get-ChildItem -Path $nestedModulesFolderPath -Recurse -Depth 2 -File -ErrorAction SilentlyContinue -Filter '*.dll' |
+        $requiredAssemblies += Get-ChildItem -Path $nestedModulesFolderPath -Recurse -Depth 1 -File -ErrorAction SilentlyContinue -Filter '*.dll' |
             Select-Object -ExpandProperty FullName |
             ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart([System.IO.Path]::DirectorySeparatorChar) }
         $manifest.RequiredAssemblies = if ($existingRequiredAssemblies) { $existingRequiredAssemblies } elseif ($requiredAssemblies.Count -gt 0) { @($requiredAssemblies) } else { @() }
@@ -124,7 +124,7 @@ function Build-PSModuleManifest {
 
         Write-Host '[NestedModules]'
         $existingNestedModules = $manifest.NestedModules
-        $nestedModules = Get-ChildItem -Path $nestedModulesFolderPath -Recurse -Depth 2 -File -ErrorAction SilentlyContinue -Include '*.psm1', '*.ps1', '*.dll' |
+        $nestedModules = Get-ChildItem -Path $nestedModulesFolderPath -Recurse -Depth 1 -File -ErrorAction SilentlyContinue -Include '*.psm1', '*.ps1', '*.dll' |
             Select-Object -ExpandProperty FullName |
             ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart([System.IO.Path]::DirectorySeparatorChar) }
         $manifest.NestedModules = if ($existingNestedModules) { $existingNestedModules } elseif ($nestedModules.Count -gt 0) { @($nestedModules) } else { @() }

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -109,37 +109,38 @@ function Build-PSModuleManifest {
         $manifest.FileList | ForEach-Object { Write-Host "[FileList] - [$_]" }
 
         Write-Host '[RequiredAssemblies]'
+        $existingRequiredAssemblies = $manifest.RequiredAssemblies
         $requiredAssembliesFolderPath = Join-Path $ModuleOutputFolder 'assemblies'
-        $requiredAssemblies = Get-ChildItem -Path $RequiredAssembliesFolderPath -Recurse -File -ErrorAction SilentlyContinue -Filter '*.dll' |
+        $requiredAssemblies = Get-ChildItem -Path $requiredAssembliesFolderPath -Recurse -File -ErrorAction SilentlyContinue -Filter '*.dll' |
             Select-Object -ExpandProperty FullName |
-            ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart($pathSeparator) }
-        $manifest.RequiredAssemblies = $requiredAssemblies.count -eq 0 ? @() : @($requiredAssemblies)
+            ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart([System.IO.Path]::DirectorySeparatorChar) }
+        $manifest.RequiredAssemblies = if ($existingRequiredAssemblies) { $existingRequiredAssemblies } elseif ($requiredAssemblies.Count -gt 0) { @($requiredAssemblies) } else { @() }
         $manifest.RequiredAssemblies | ForEach-Object { Write-Host "[RequiredAssemblies] - [$_]" }
 
         Write-Host '[NestedModules]'
+        $existingNestedModules = $manifest.NestedModules
         $nestedModulesFolderPath = Join-Path $ModuleOutputFolder 'modules'
         $nestedModules = Get-ChildItem -Path $nestedModulesFolderPath -Recurse -File -ErrorAction SilentlyContinue -Include '*.psm1', '*.ps1' |
             Select-Object -ExpandProperty FullName |
-            ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart($pathSeparator) }
-        $manifest.NestedModules = $nestedModules.count -eq 0 ? @() : @($nestedModules)
+            ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart([System.IO.Path]::DirectorySeparatorChar) }
+        $manifest.NestedModules = if ($existingNestedModules) { $existingNestedModules } elseif ($nestedModules.Count -gt 0) { @($nestedModules) } else { @() }
         $manifest.NestedModules | ForEach-Object { Write-Host "[NestedModules] - [$_]" }
 
         Write-Host '[ScriptsToProcess]'
+        $existingScriptsToProcess = $manifest.ScriptsToProcess
         $allScriptsToProcess = @('scripts') | ForEach-Object {
             Write-Host "[ScriptsToProcess] - Processing [$_]"
             $scriptsFolderPath = Join-Path $ModuleOutputFolder $_
-            $scriptsToProcess = Get-ChildItem -Path $scriptsFolderPath -Recurse -File -ErrorAction SilentlyContinue -Include '*.ps1' |
-                Select-Object -ExpandProperty FullName |
-                ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart($pathSeparator) }
-                $scriptsToProcess
-            }
-            $manifest.ScriptsToProcess = $allScriptsToProcess.count -eq 0 ? @() : @($allScriptsToProcess)
-            $manifest.ScriptsToProcess | ForEach-Object { Write-Host "[ScriptsToProcess] - [$_]" }
+            Get-ChildItem -Path $scriptsFolderPath -Recurse -File -ErrorAction SilentlyContinue -Include '*.ps1' | Select-Object -ExpandProperty FullName | ForEach-Object {
+                $_.Replace($ModuleOutputFolder, '').TrimStart([System.IO.Path]::DirectorySeparatorChar) }
+        }
+        $manifest.ScriptsToProcess = if ($existingScriptsToProcess) { $existingScriptsToProcess } elseif ($allScriptsToProcess.Count -gt 0) { @($allScriptsToProcess) } else { @() }
+        $manifest.ScriptsToProcess | ForEach-Object { Write-Host "[ScriptsToProcess] - [$_]" }
 
-            Write-Host '[TypesToProcess]'
-            $typesToProcess = Get-ChildItem -Path $ModuleOutputFolder -Recurse -File -ErrorAction SilentlyContinue -Include '*.Types.ps1xml' |
-                Select-Object -ExpandProperty FullName |
-                ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart($pathSeparator) }
+        Write-Host '[TypesToProcess]'
+        $typesToProcess = Get-ChildItem -Path $ModuleOutputFolder -Recurse -File -ErrorAction SilentlyContinue -Include '*.Types.ps1xml' |
+            Select-Object -ExpandProperty FullName |
+            ForEach-Object { $_.Replace($ModuleOutputFolder, '').TrimStart($pathSeparator) }
         $manifest.TypesToProcess = $typesToProcess.count -eq 0 ? @() : @($typesToProcess)
         $manifest.TypesToProcess | ForEach-Object { Write-Host "[TypesToProcess] - [$_]" }
 


### PR DESCRIPTION
## Description

This pull request includes updates to the `Build-PSModuleManifest` function in the `scripts/helpers/Build/Build-PSModuleManifest.ps1` file. The changes aim to improve the handling of manifest properties by preserving existing values when they are present.

Key changes include:

* **Handling of `RequiredAssemblies`:**
  - Added logic to preserve existing `RequiredAssemblies` values if they are present, otherwise populate with new values or set to an empty array if none are found. Now also includes `*.dll` files under the `modules` folder of the built module (non recursive).

* **Handling of `NestedModules`:**
  - Added logic to preserve existing `NestedModules` values if they are present, otherwise populate with new values or set to an empty array if none are found. Now also includes *.dll files under the `modules` folder of the built module. Will only look on one level down, not recursively within each subfolder.

* **Handling of `ScriptsToProcess`:**
  - Added logic to preserve existing `ScriptsToProcess` values if they are present, otherwise populate with new values or set to an empty array if none are found.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
