### PR TITLE
🩹 [Patch]: Swap out `Utilities` with `Hashtable`

### DIFF
--- a/scripts/helpers/Build/Build-PSModuleRootModule.ps1
+++ b/scripts/helpers/Build/Build-PSModuleRootModule.ps1
@@ -1,5 +1,5 @@
 ﻿#Requires -Modules @{ ModuleName = 'GitHub'; ModuleVersion = '0.13.2' }
-#Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
+#Requires -Modules @{ ModuleName = 'Hashtable'; ModuleVersion = '1.1.1' }
 
 function Build-PSModuleRootModule {
     <#
@@ -222,7 +222,7 @@ Write-Debug "[`$scriptName] - $relativePath - Done"
         #region - Export-ModuleMember
         Add-Content -Path $rootModuleFile -Force -Value $classExports
 
-        $exportsString = Convert-HashtableToString -Hashtable $exports
+        $exportsString = $exports | Format-Hashtable
 
         Write-Host ($exportsString | Out-String)
 


### PR DESCRIPTION
## Description

This pull request includes changes a dependency in `Build-PSModuleRootModule.ps1` to use `Hashtable` instead of Utilities`.

Updates to module dependencies:

* [`scripts/helpers/Build/Build-PSModuleRootModule.ps1`](diffhunk://#diff-1d337ff39f37506a54fda1c5d0487f1b2c2ef318f216a4d9a56c3e7248b69879L2-R2): Changed the required module from `Utilities` version `0.3.0` to `Hashtable` version `1.1.1`.

Improvements to export process:

* [`scripts/helpers/Build/Build-PSModuleRootModule.ps1`](diffhunk://#diff-1d337ff39f37506a54fda1c5d0487f1b2c2ef318f216a4d9a56c3e7248b69879L225-R225): Replaced the `Convert-HashtableToString` function with the `Format-Hashtable` function to format hashtable exports.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
