### PR TITLE
🪲 [Fix]: Fix `Variables` being `$null`

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -35,6 +35,24 @@ jobs:
           Path: tests/src
           ModulesOutputPath: tests/outputs/modules
 
+  ActionTestMinimal:
+    name: Action-Test - [Minimal]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Initialize environment
+        uses: PSModule/Initialize-PSModule@main
+
+      - name: Action-Test
+        uses: ./
+        with:
+          Name: PSModuleTest
+          Path: tests/srcMinimal
+          ModulesOutputPath: tests/outputs/modules
+          ModuleArtifactName: moduleMinimal
+
   ActionTestWithManifest:
     name: Action-Test - [DefaultWithManifest]
     runs-on: ubuntu-24.04

--- a/scripts/helpers/Build/Get-PSModuleVariablesToExport.ps1
+++ b/scripts/helpers/Build/Get-PSModuleVariablesToExport.ps1
@@ -14,6 +14,7 @@
         'PSAvoidUsingWriteHost', '', Scope = 'Function',
         Justification = 'Want to just write to the console, not the pipeline.'
     )]
+    [OutputType([string[]])]
     [CmdletBinding()]
     param(
         # Path to the folder where the module source code is located.
@@ -29,7 +30,7 @@
     $variableFolderPath = Join-Path -Path $SourceFolderPath -ChildPath 'variables/public'
     if (-not (Test-Path -Path $variableFolderPath -PathType Container)) {
         Write-Host "[$manifestPropertyName] - [Folder not found] - [$variableFolderPath]"
-        return $variablesToExport
+        return ''
     }
     $scriptFilePaths = Get-ChildItem -Path $variableFolderPath -Recurse -File -Filter *.ps1 | Select-Object -ExpandProperty FullName
 

--- a/scripts/helpers/Build/Get-PSModuleVariablesToExport.ps1
+++ b/scripts/helpers/Build/Get-PSModuleVariablesToExport.ps1
@@ -25,6 +25,7 @@
 
     Write-Host "[$manifestPropertyName]"
 
+    $variablesToExport = [Collections.Generic.List[string]]::new()
     $variableFolderPath = Join-Path -Path $SourceFolderPath -ChildPath 'variables/public'
     if (-not (Test-Path -Path $variableFolderPath -PathType Container)) {
         Write-Host "[$manifestPropertyName] - [Folder not found] - [$variableFolderPath]"
@@ -32,7 +33,6 @@
     }
     $scriptFilePaths = Get-ChildItem -Path $variableFolderPath -Recurse -File -Filter *.ps1 | Select-Object -ExpandProperty FullName
 
-    $variablesToExport = [Collections.Generic.List[string]]::new()
     $scriptFilePaths | ForEach-Object {
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($_, [ref]$null, [ref]$null)
         $variables = Get-RootLevelVariable -Ast $ast

--- a/scripts/helpers/Build/Get-PSModuleVariablesToExport.ps1
+++ b/scripts/helpers/Build/Get-PSModuleVariablesToExport.ps1
@@ -9,12 +9,12 @@
         .EXAMPLE
         Get-PSModuleVariablesToExport -SourceFolderPath 'C:\MyModule\src\MyModule'
     #>
-    [OutputType([Collections.Generic.List[string]])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSAvoidUsingWriteHost', '', Scope = 'Function',
         Justification = 'Want to just write to the console, not the pipeline.'
     )]
-    [OutputType([string[]])]
+    [OutputType([string])]
+    [OutputType([Collections.Generic.List[string]])]
     [CmdletBinding()]
     param(
         # Path to the folder where the module source code is located.

--- a/tests/srcMinimal/functions/public/Test-PSModuleTest.ps1
+++ b/tests/srcMinimal/functions/public/Test-PSModuleTest.ps1
@@ -1,0 +1,18 @@
+﻿function Test-PSModuleTest {
+    <#
+        .SYNOPSIS
+        Performs tests on a module.
+
+        .EXAMPLE
+        Test-PSModule -Name 'World'
+
+        "Hello, World!"
+    #>
+    [CmdletBinding()]
+    param (
+        # Name of the person to greet.
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+    Write-Output "Hello, $Name!"
+}


### PR DESCRIPTION
## Description

This pull request includes a minor change to the `Get-PSModuleVariablesToExport.ps1` script. The change involves moving the initialization of the `$variablesToExport` variable to an earlier point in the script to ensure it is defined before any potential early returns.

* [`scripts/helpers/Build/Get-PSModuleVariablesToExport.ps1`](diffhunk://#diff-e2148fcf63283d70b3d432f67fc98191e2cc712dc3f4d30914c8c0810d11a6deR28-L35): Moved the initialization of `$variablesToExport` to before the folder existence check to ensure it is always defined.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
