### PR TITLE
🩹 [Patch]: Remove dependency on `Utilities`

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@re
+        uses: PSModule/Initialize-PSModule@v1
 
       - name: Action-Test
         uses: ./
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@re
+        uses: PSModule/Initialize-PSModule@v1
 
       - name: Action-Test
         uses: ./
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@re
+        uses: PSModule/Initialize-PSModule@v1
 
       - name: Action-Test
         uses: ./

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@main
+        uses: PSModule/Initialize-PSModule@re
 
       - name: Action-Test
         uses: ./
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@main
+        uses: PSModule/Initialize-PSModule@re
 
       - name: Action-Test
         uses: ./
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize environment
-        uses: PSModule/Initialize-PSModule@main
+        uses: PSModule/Initialize-PSModule@re
 
       - name: Action-Test
         uses: ./

--- a/scripts/helpers/Build-PSModule.ps1
+++ b/scripts/helpers/Build-PSModule.ps1
@@ -8,7 +8,6 @@
     #>
     [CmdletBinding()]
     #Requires -Modules @{ ModuleName = 'GitHub'; ModuleVersion = '0.13.2' }
-    #Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSReviewUnusedParameter', '', Scope = 'Function',
         Justification = 'LogGroup - Scoping affects the variables line of sight.'

--- a/scripts/helpers/Build/Add-ModuleManifestData.ps1
+++ b/scripts/helpers/Build/Add-ModuleManifestData.ps1
@@ -1,0 +1,164 @@
+﻿function Add-ModuleManifestData {
+    <#
+        .SYNOPSIS
+        Add data to a module manifest file property
+
+        .DESCRIPTION
+        This function adds data to a module manifest file property.
+        If the property doesn't exist, it will be created.
+        If it does exist, the new data will be appended to the existing data.
+
+        .EXAMPLE
+        Add-ModuleManifestData -Path 'MyModule.psd1' -RequiredModules 'pester', 'platyPS'
+
+        Adds the modules 'pester' and 'platyPS' to the RequiredModules property of the module manifest file 'MyModule.psd1'.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateScript({ Test-Path -Path $_ -PathType Leaf })]
+        [string]$Path,
+
+        # Modules that must be imported into the global environment prior to importing this module.
+        [Parameter()]
+        [Object[]] $RequiredModules,
+
+        # Compatible editions of PowerShell.
+        [Parameter()]
+        [string[]] $CompatiblePSEditions,
+
+        # Assemblies that must be loaded prior to importing this module.
+        [Parameter()]
+        [string[]] $RequiredAssemblies,
+
+        # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+        [Parameter()]
+        [string[]] $ScriptsToProcess,
+
+        # Type files (.ps1xml) to be loaded when importing this module.
+        [Parameter()]
+        [string[]] $TypesToProcess,
+
+        # Format files (.ps1xml) to be loaded when importing this module.
+        [Parameter()]
+        [string[]] $FormatsToProcess,
+
+        # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess.
+        [Parameter()]
+        [Object[]] $NestedModules,
+
+        # Functions to export from this module, for best performance, do not use wildcards and do not
+        # delete the entry, use an empty array if there are no functions to export.
+        [Parameter()]
+        [string[]] $FunctionsToExport,
+
+        # Cmdlets to export from this module, for best performance, do not use wildcards and do not
+        # delete the entry, use an empty array if there are no cmdlets to export.
+        [Parameter()]
+        [string[]] $CmdletsToExport,
+
+        # Variables to export from this module.
+        [Parameter()]
+        [string[]] $VariablesToExport,
+
+        # Aliases to export from this module, for best performance, do not use wildcards and do not
+        # delete the entry, use an empty array if there are no aliases to export.
+        [Parameter()]
+        [string[]] $AliasesToExport,
+
+        # DSC resources to export from this module.
+        [Parameter()]
+        [string[]] $DscResourcesToExport,
+
+        # List of all modules packaged with this module.
+        [Parameter()]
+        [Object[]] $ModuleList,
+
+        # List of all files packaged with this module.
+        [Parameter()]
+        [string[]] $FileList,
+
+        # Tags applied to this module. These help with module discovery in online galleries.
+        [Parameter()]
+        [string[]] $Tags,
+
+        # External dependent modules of this module.
+        [Parameter()]
+        [string[]] $ExternalModuleDependencies
+    )
+
+    $moduleManifest = Get-ModuleManifest -Path $Path
+    $changes = @{}
+
+    if ($RequiredModules) {
+        $RequiredModules += $moduleManifest.RequiredModules
+        $changes.RequiredModules = $RequiredModules
+    }
+    if ($RequiredAssemblies) {
+        $RequiredAssemblies += $moduleManifest.RequiredAssemblies
+        $changes.RequiredAssemblies = $RequiredAssemblies
+    }
+    if ($CompatiblePSEditions) {
+        $CompatiblePSEditions += $moduleManifest.CompatiblePSEditions
+        $changes.CompatiblePSEditions = $CompatiblePSEditions
+    }
+    if ($ScriptsToProcess) {
+        $ScriptsToProcess += $moduleManifest.ScriptsToProcess
+        $changes.ScriptsToProcess = $ScriptsToProcess
+    }
+    if ($TypesToProcess) {
+        $TypesToProcess += $moduleManifest.TypesToProcess
+        $changes.TypesToProcess = $TypesToProcess
+    }
+    if ($FormatsToProcess) {
+        $FormatsToProcess += $moduleManifest.FormatsToProcess
+        $changes.FormatsToProcess = $FormatsToProcess
+    }
+    if ($NestedModules) {
+        $NestedModules += $moduleManifest.NestedModules
+        $changes.NestedModules = $NestedModules
+    }
+    if ($FunctionsToExport) {
+        $FunctionsToExport += $moduleManifest.FunctionsToExport
+        $changes.FunctionsToExport = $FunctionsToExport
+    }
+    if ($CmdletsToExport) {
+        $CmdletsToExport += $moduleManifest.CmdletsToExport
+        $changes.CmdletsToExport = $CmdletsToExport
+    }
+    if ($VariablesToExport) {
+        $VariablesToExport += $moduleManifest.VariablesToExport
+        $changes.VariablesToExport = $VariablesToExport
+    }
+    if ($AliasesToExport) {
+        $AliasesToExport += $moduleManifest.AliasesToExport
+        $changes.AliasesToExport = $AliasesToExport
+    }
+    if ($DscResourcesToExport) {
+        $DscResourcesToExport += $moduleManifest.DscResourcesToExport
+        $changes.DscResourcesToExport = $DscResourcesToExport
+    }
+    if ($ModuleList) {
+        $ModuleList += $moduleManifest.ModuleList
+        $changes.ModuleList = $ModuleList
+    }
+    if ($FileList) {
+        $FileList += $moduleManifest.FileList
+        $changes.FileList = $FileList
+    }
+    if ($Tags) {
+        $Tags += $moduleManifest.PrivateData.PSData.Tags
+        $changes.Tags = $Tags
+    }
+    if ($ExternalModuleDependencies) {
+        $ExternalModuleDependencies += $moduleManifest.PrivateData.PSData.ExternalModuleDependencies
+        $changes.ExternalModuleDependencies = $ExternalModuleDependencies
+    }
+
+    foreach ($key in $changes.GetEnumerator().Name) {
+        $changes[$key] = $changes[$key] | Sort-Object -Unique | Where-Object { $_ | IsNotNullOrEmpty }
+    }
+
+    Set-ModuleManifest -Path $Path @changes
+
+}

--- a/scripts/helpers/Build/Add-ModuleManifestData.ps1
+++ b/scripts/helpers/Build/Add-ModuleManifestData.ps1
@@ -156,7 +156,7 @@
     }
 
     foreach ($key in $changes.GetEnumerator().Name) {
-        $changes[$key] = $changes[$key] | Sort-Object -Unique | Where-Object { $_ | IsNotNullOrEmpty }
+        $changes[$key] = $changes[$key] | Sort-Object -Unique | Where-Object { -not [string]::IsNullOrEmpty($_) }
     }
 
     Set-ModuleManifest -Path $Path @changes

--- a/scripts/helpers/Build/Add-PSModulePath.ps1
+++ b/scripts/helpers/Build/Add-PSModulePath.ps1
@@ -1,0 +1,29 @@
+﻿function Add-PSModulePath {
+    <#
+        .SYNOPSIS
+        Adds a path to the PSModulePath environment variable.
+
+        .DESCRIPTION
+        Adds a path to the PSModulePath environment variable.
+        For Linux and macOS, the path delimiter is ':' and for Windows it is ';'.
+
+        .EXAMPLE
+        Add-PSModulePath -Path 'C:\Users\user\Documents\WindowsPowerShell\Modules'
+
+        Adds the path 'C:\Users\user\Documents\WindowsPowerShell\Modules' to the PSModulePath environment variable.
+    #>
+    [CmdletBinding()]
+    param(
+        # Path to the folder where the module source code is located.
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+    $PSModulePathSeparator = [System.IO.Path]::PathSeparator
+
+    $env:PSModulePath += "$PSModulePathSeparator$Path"
+
+    Write-Verbose 'PSModulePath:'
+    $env:PSModulePath.Split($PSModulePathSeparator) | ForEach-Object {
+        Write-Verbose " - [$_]"
+    }
+}

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -60,10 +60,10 @@
         $manifest.ModuleVersion = '999.0.0'
         Write-Host "[ModuleVersion] - [$($manifest.ModuleVersion)]"
 
-        $manifest.Author = $manifest.Keys -contains 'Author' ? ($manifest.Author | IsNotNullOrEmpty) ? $manifest.Author : $env:GITHUB_REPOSITORY_OWNER : $env:GITHUB_REPOSITORY_OWNER
+        $manifest.Author = $manifest.Keys -contains 'Author' ? -not [string]::IsNullOrEmpty($manifest.Author) ? $manifest.Author : $env:GITHUB_REPOSITORY_OWNER : $env:GITHUB_REPOSITORY_OWNER
         Write-Host "[Author] - [$($manifest.Author)]"
 
-        $manifest.CompanyName = $manifest.Keys -contains 'CompanyName' ? ($manifest.CompanyName | IsNotNullOrEmpty) ? $manifest.CompanyName : $env:GITHUB_REPOSITORY_OWNER : $env:GITHUB_REPOSITORY_OWNER
+        $manifest.CompanyName = $manifest.Keys -contains 'CompanyName' ? -not [string]::IsNullOrEmpty($manifest.CompanyName) ? $manifest.CompanyName : $env:GITHUB_REPOSITORY_OWNER : $env:GITHUB_REPOSITORY_OWNER
         Write-Host "[CompanyName] - [$($manifest.CompanyName)]"
 
         $year = Get-Date -Format 'yyyy'
@@ -73,7 +73,7 @@
         Write-Host "[Copyright] - [$($manifest.Copyright)]"
 
         $repoDescription = gh repo view --json description | ConvertFrom-Json | Select-Object -ExpandProperty description
-        $manifest.Description = $manifest.Keys -contains 'Description' ? ($manifest.Description | IsNotNullOrEmpty) ? $manifest.Description : $repoDescription : $repoDescription
+        $manifest.Description = $manifest.Keys -contains 'Description' ? -not [string]::IsNullOrEmpty($manifest.Description) ? $manifest.Description : $repoDescription : $repoDescription
         Write-Host "[Description] - [$($manifest.Description)]"
 
         $manifest.PowerShellHostName = $manifest.Keys -contains 'PowerShellHostName' ? -not [string]::IsNullOrEmpty($manifest.PowerShellHostName) ? $manifest.PowerShellHostName : $null : $null

--- a/scripts/helpers/Build/Build-PSModuleManifest.ps1
+++ b/scripts/helpers/Build/Build-PSModuleManifest.ps1
@@ -12,7 +12,6 @@
     #>
     [CmdletBinding()]
     #Requires -Modules @{ ModuleName = 'GitHub'; ModuleVersion = '0.13.2' }
-    #Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSAvoidLongLines', '', Scope = 'Function',
         Justification = 'Easier to read the multi ternery operators in a single line.'

--- a/scripts/helpers/Build/Export-PowerShellDataFile.ps1
+++ b/scripts/helpers/Build/Export-PowerShellDataFile.ps1
@@ -24,7 +24,7 @@
         [switch] $Force
     )
 
-    $content = Convert-HashtableToString -Hashtable $Hashtable
+    $content = Format-Hashtable -Hashtable $Hashtable
     $content | Out-File -FilePath $Path -Force:$Force
     Format-ModuleManifest -Path $Path
 }

--- a/scripts/helpers/Build/Export-PowerShellDataFile.ps1
+++ b/scripts/helpers/Build/Export-PowerShellDataFile.ps1
@@ -1,0 +1,30 @@
+﻿function Export-PowerShellDataFile {
+    <#
+        .SYNOPSIS
+        Export a hashtable to a .psd1 file.
+
+        .DESCRIPTION
+        This function exports a hashtable to a .psd1 file. It also formats the .psd1 file using the Format-ModuleManifest cmdlet.
+
+        .EXAMPLE
+        Export-PowerShellDataFile -Hashtable @{ Name = 'MyModule'; ModuleVersion = '1.0.0' } -Path 'MyModule.psd1'
+    #>
+    [CmdletBinding()]
+    param (
+        # The hashtable to export to a .psd1 file.
+        [Parameter(Mandatory)]
+        [object] $Hashtable,
+
+        # The path of the .psd1 file to export.
+        [Parameter(Mandatory)]
+        [string] $Path,
+
+        # Force the export, even if the file already exists.
+        [Parameter()]
+        [switch] $Force
+    )
+
+    $content = Convert-HashtableToString -Hashtable $Hashtable
+    $content | Out-File -FilePath $Path -Force:$Force
+    Format-ModuleManifest -Path $Path
+}

--- a/scripts/helpers/Build/Format-ModuleManifest.ps1
+++ b/scripts/helpers/Build/Format-ModuleManifest.ps1
@@ -1,0 +1,32 @@
+﻿function Format-ModuleManifest {
+    <#
+        .SYNOPSIS
+        Formats a module manifest file.
+
+        .DESCRIPTION
+        This function formats a module manifest file, by removing comments and empty lines,
+        and then formatting the file using the `Invoke-Formatter` function.
+
+        .EXAMPLE
+        Format-ModuleManifest -Path 'C:\MyModule\MyModule.psd1'
+    #>
+    [CmdletBinding()]
+    param(
+        # Path to the module manifest file.
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    $Utf8BomEncoding = New-Object System.Text.UTF8Encoding $true
+
+    $manifestContent = Get-Content -Path $Path
+    $manifestContent = $manifestContent | ForEach-Object { $_ -replace '#.*' }
+    $manifestContent = $manifestContent | ForEach-Object { $_.TrimEnd() }
+    $manifestContent = $manifestContent | Where-Object { $_ | IsNotNullOrEmpty }
+    [System.IO.File]::WriteAllLines($Path, $manifestContent, $Utf8BomEncoding)
+    $manifestContent = Get-Content -Path $Path -Raw
+
+    $content = Invoke-Formatter -ScriptDefinition $manifestContent
+    [System.IO.File]::WriteAllLines($Path, $content, $Utf8BomEncoding)
+
+}

--- a/scripts/helpers/Build/Format-ModuleManifest.ps1
+++ b/scripts/helpers/Build/Format-ModuleManifest.ps1
@@ -22,7 +22,7 @@
     $manifestContent = Get-Content -Path $Path
     $manifestContent = $manifestContent | ForEach-Object { $_ -replace '#.*' }
     $manifestContent = $manifestContent | ForEach-Object { $_.TrimEnd() }
-    $manifestContent = $manifestContent | Where-Object { $_ | IsNotNullOrEmpty }
+    $manifestContent = $manifestContent | Where-Object { -not [string]::IsNullOrEmpty($_) }
     [System.IO.File]::WriteAllLines($Path, $manifestContent, $Utf8BomEncoding)
     $manifestContent = Get-Content -Path $Path -Raw
 

--- a/scripts/helpers/Build/Get-ModuleManifest.ps1
+++ b/scripts/helpers/Build/Get-ModuleManifest.ps1
@@ -1,0 +1,121 @@
+﻿function Get-ModuleManifest {
+    <#
+        .SYNOPSIS
+        Get the module manifest.
+
+        .DESCRIPTION
+        Get the module manifest as a path, file info, content, or hashtable.
+
+        .EXAMPLE
+        Get-PSModuleManifest -Path 'src/PSModule/PSModule.psd1' -As Hashtable
+    #>
+    [OutputType([string], [System.IO.FileInfo], [System.Collections.Hashtable], [System.Collections.Specialized.OrderedDictionary])]
+    [CmdletBinding()]
+    param(
+        # Path to the module manifest file.
+        [Parameter(Mandatory)]
+        [string] $Path,
+
+        # The format of the output.
+        [Parameter()]
+        [ValidateSet('FileInfo', 'Content', 'Hashtable')]
+        [string] $As = 'Hashtable'
+    )
+
+    if (-not (Test-Path -Path $Path)) {
+        Write-Warning 'No manifest file found.'
+        return $null
+    }
+    Write-Verbose "Found manifest file [$Path]"
+
+    switch ($As) {
+        'FileInfo' {
+            return Get-Item -Path $Path
+        }
+        'Content' {
+            return Get-Content -Path $Path
+        }
+        'Hashtable' {
+            $manifest = [System.Collections.Specialized.OrderedDictionary]@{}
+            $psData = [System.Collections.Specialized.OrderedDictionary]@{}
+            $privateData = [System.Collections.Specialized.OrderedDictionary]@{}
+            $tempManifest = Import-PowerShellDataFile -Path $Path
+            if ($tempManifest.ContainsKey('PrivateData')) {
+                $tempPrivateData = $tempManifest.PrivateData
+                if ($tempPrivateData.ContainsKey('PSData')) {
+                    $tempPSData = $tempPrivateData.PSData
+                    $tempPrivateData.Remove('PSData')
+                }
+            }
+
+            $psdataOrder = @(
+                'Tags'
+                'LicenseUri'
+                'ProjectUri'
+                'IconUri'
+                'ReleaseNotes'
+                'Prerelease'
+                'RequireLicenseAcceptance'
+                'ExternalModuleDependencies'
+            )
+            foreach ($key in $psdataOrder) {
+                if (($null -ne $tempPSData) -and ($tempPSData.ContainsKey($key))) {
+                    $psData.$key = $tempPSData.$key
+                }
+            }
+            if ($psData.Count -gt 0) {
+                $privateData.PSData = $psData
+            } else {
+                $privateData.Remove('PSData')
+            }
+            foreach ($key in $tempPrivateData.Keys) {
+                $privateData.$key = $tempPrivateData.$key
+            }
+
+            $manifestOrder = @(
+                'RootModule'
+                'ModuleVersion'
+                'CompatiblePSEditions'
+                'GUID'
+                'Author'
+                'CompanyName'
+                'Copyright'
+                'Description'
+                'PowerShellVersion'
+                'PowerShellHostName'
+                'PowerShellHostVersion'
+                'DotNetFrameworkVersion'
+                'ClrVersion'
+                'ProcessorArchitecture'
+                'RequiredModules'
+                'RequiredAssemblies'
+                'ScriptsToProcess'
+                'TypesToProcess'
+                'FormatsToProcess'
+                'NestedModules'
+                'FunctionsToExport'
+                'CmdletsToExport'
+                'VariablesToExport'
+                'AliasesToExport'
+                'DscResourcesToExport'
+                'ModuleList'
+                'FileList'
+                'HelpInfoURI'
+                'DefaultCommandPrefix'
+                'PrivateData'
+            )
+            foreach ($key in $manifestOrder) {
+                if ($tempManifest.ContainsKey($key)) {
+                    $manifest.$key = $tempManifest.$key
+                }
+            }
+            if ($privateData.Count -gt 0) {
+                $manifest.PrivateData = $privateData
+            } else {
+                $manifest.Remove('PrivateData')
+            }
+
+            return $manifest
+        }
+    }
+}

--- a/scripts/helpers/Build/Get-PSModuleAliasesToExport.ps1
+++ b/scripts/helpers/Build/Get-PSModuleAliasesToExport.ps1
@@ -10,7 +10,6 @@
         Get-PSModuleAliasesToExport -SourceFolderPath 'C:\MyModule\src\MyModule'
     #>
     [CmdletBinding()]
-    #Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSAvoidUsingWriteHost', '', Scope = 'Function',
         Justification = 'Want to just write to the console, not the pipeline.'

--- a/scripts/helpers/Build/Get-PSModuleAliasesToExport.ps1
+++ b/scripts/helpers/Build/Get-PSModuleAliasesToExport.ps1
@@ -30,7 +30,8 @@
     $manifest = Get-ModuleManifest -Path $manifestFilePath -Verbose:$false
 
     Write-Host "[$manifestPropertyName]"
-    $aliasesToExport = (($manifest.AliasesToExport).count -eq 0) -or ($manifest.AliasesToExport | IsNullOrEmpty) ? '*' : $manifest.AliasesToExport
+    $aliasesToExport = (($manifest.AliasesToExport).count -eq 0) -or [string]::IsNullOrEmpty($manifest.AliasesToExport) ?
+    '*' : $manifest.AliasesToExport
     $aliasesToExport | ForEach-Object {
         Write-Host "[$manifestPropertyName] - [$_]"
     }

--- a/scripts/helpers/Build/Get-PSModuleCmdletsToExport.ps1
+++ b/scripts/helpers/Build/Get-PSModuleCmdletsToExport.ps1
@@ -30,7 +30,8 @@
     $manifest = Get-ModuleManifest -Path $manifestFilePath -Verbose:$false
 
     Write-Host "[$manifestPropertyName]"
-    $cmdletsToExport = (($manifest.CmdletsToExport).count -eq 0) -or ($manifest.CmdletsToExport | IsNullOrEmpty) ? '' : $manifest.CmdletsToExport
+    $cmdletsToExport = (($manifest.CmdletsToExport).count -eq 0) -or [string]::IsNullOrEmpty($manifest.CmdletsToExport) ?
+    '' : $manifest.CmdletsToExport
     $cmdletsToExport | ForEach-Object {
         Write-Host "[$manifestPropertyName] - [$_]"
     }

--- a/scripts/helpers/Build/Get-PSModuleCmdletsToExport.ps1
+++ b/scripts/helpers/Build/Get-PSModuleCmdletsToExport.ps1
@@ -10,7 +10,6 @@
         Get-PSModuleCmdletsToExport -SourceFolderPath 'C:\MyModule\src\MyModule'
     #>
     [CmdletBinding()]
-    #Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
         'PSAvoidUsingWriteHost', '', Scope = 'Function',
         Justification = 'Want to just write to the console, not the pipeline.'

--- a/scripts/helpers/Build/Import-PSModule.ps1
+++ b/scripts/helpers/Build/Import-PSModule.ps1
@@ -16,7 +16,6 @@
         'PSAvoidUsingWriteHost', '', Scope = 'Function',
         Justification = 'Want to just write to the console, not the pipeline.'
     )]
-    #Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
     param(
         # Path to the folder where the module source code is located.
         [Parameter(Mandatory)]

--- a/scripts/helpers/Build/Set-ModuleManifest.ps1
+++ b/scripts/helpers/Build/Set-ModuleManifest.ps1
@@ -1,0 +1,325 @@
+﻿filter Set-ModuleManifest {
+    <#
+        .SYNOPSIS
+        Sets the values of a module manifest file.
+
+        .DESCRIPTION
+        This function sets the values of a module manifest file.
+        Very much like the Update-ModuleManifest function, but allows values to be missing.
+
+        .EXAMPLE
+        Set-ModuleManifest -Path 'C:\MyModule\MyModule.psd1' -ModuleVersion '1.0.0'
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Function does not change state.'
+    )]
+    [CmdletBinding()]
+    param(
+        # Path to the module manifest file.
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
+        )]
+        [string] $Path,
+
+        #Script module or binary module file associated with this manifest.
+        [Parameter()]
+        [AllowNull()]
+        [string] $RootModule,
+
+        #Version number of this module.
+        [Parameter()]
+        [AllowNull()]
+        [Version] $ModuleVersion,
+
+        # Supported PSEditions.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $CompatiblePSEditions,
+
+        # ID used to uniquely identify this module.
+        [Parameter()]
+        [AllowNull()]
+        [guid] $GUID,
+
+        # Author of this module.
+        [Parameter()]
+        [AllowNull()]
+        [string] $Author,
+
+        # Company or vendor of this module.
+        [Parameter()]
+        [AllowNull()]
+        [string] $CompanyName,
+
+        # Copyright statement for this module.
+        [Parameter()]
+        [AllowNull()]
+        [string] $Copyright,
+
+        # Description of the functionality provided by this module.
+        [Parameter()]
+        [AllowNull()]
+        [string] $Description,
+
+        # Minimum version of the PowerShell engine required by this module.
+        [Parameter()]
+        [AllowNull()]
+        [Version] $PowerShellVersion,
+
+        # Name of the PowerShell host required by this module.
+        [Parameter()]
+        [AllowNull()]
+        [string] $PowerShellHostName,
+
+        # Minimum version of the PowerShell host required by this module.
+        [Parameter()]
+        [AllowNull()]
+        [version] $PowerShellHostVersion,
+
+        # Minimum version of Microsoft .NET Framework required by this module.
+        # This prerequisite is valid for the PowerShell Desktop edition only.
+        [Parameter()]
+        [AllowNull()]
+        [Version] $DotNetFrameworkVersion,
+
+        # Minimum version of the common language runtime (CLR) required by this module.
+        # This prerequisite is valid for the PowerShell Desktop edition only.
+        [Parameter()]
+        [AllowNull()]
+        [Version] $ClrVersion,
+
+        # Processor architecture (None,X86, Amd64) required by this module
+        [Parameter()]
+        [AllowNull()]
+        [System.Reflection.ProcessorArchitecture] $ProcessorArchitecture,
+
+        # Modules that must be imported into the global environment prior to importing this module.
+        [Parameter()]
+        [AllowNull()]
+        [Object[]] $RequiredModules,
+
+        # Assemblies that must be loaded prior to importing this module.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $RequiredAssemblies,
+
+        # Script files (.ps1) that are run in the caller's environment prior to importing this module.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $ScriptsToProcess,
+
+        # Type files (.ps1xml) to be loaded when importing this module.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $TypesToProcess,
+
+        # Format files (.ps1xml) to be loaded when importing this module.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $FormatsToProcess,
+
+        # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess.
+        [Parameter()]
+        [AllowNull()]
+        [Object[]] $NestedModules,
+
+        # Functions to export from this module, for best performance, do not use wildcards and do not
+        # delete the entry, use an empty array if there are no functions to export.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $FunctionsToExport,
+
+        # Cmdlets to export from this module, for best performance, do not use wildcards and do not
+        # delete the entry, use an empty array if there are no cmdlets to export.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $CmdletsToExport,
+
+        # Variables to export from this module.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $VariablesToExport,
+
+        # Aliases to export from this module, for best performance, do not use wildcards and do not
+        # delete the entry, use an empty array if there are no aliases to export.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $AliasesToExport,
+
+        # DSC resources to export from this module.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $DscResourcesToExport,
+
+        # List of all modules packaged with this module.
+        [Parameter()]
+        [AllowNull()]
+        [Object[]] $ModuleList,
+
+        # List of all files packaged with this module.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $FileList,
+
+        # Tags applied to this module. These help with module discovery in online galleries.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $Tags,
+
+        # A URL to the license for this module.
+        [Parameter()]
+        [AllowNull()]
+        [uri] $LicenseUri,
+
+        # A URL to the main site for this project.
+        [Parameter()]
+        [AllowNull()]
+        [uri] $ProjectUri,
+
+        # A URL to an icon representing this module.
+        [Parameter()]
+        [AllowNull()]
+        [uri] $IconUri,
+
+        # ReleaseNotes of this module.
+        [Parameter()]
+        [AllowNull()]
+        [string] $ReleaseNotes,
+
+        # Prerelease string of this module.
+        [Parameter()]
+        [AllowNull()]
+        [string] $Prerelease,
+
+        # Flag to indicate whether the module requires explicit user acceptance for install/update/save.
+        [Parameter()]
+        [AllowNull()]
+        [bool] $RequireLicenseAcceptance,
+
+        # External dependent modules of this module.
+        [Parameter()]
+        [AllowNull()]
+        [string[]] $ExternalModuleDependencies,
+
+        # HelpInfo URI of this module.
+        [Parameter()]
+        [AllowNull()]
+        [String] $HelpInfoURI,
+
+        # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+        [Parameter()]
+        [AllowNull()]
+        [string] $DefaultCommandPrefix,
+
+        # Private data to pass to the module specified in RootModule/ModuleToProcess.
+        # This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+        [Parameter()]
+        [AllowNull()]
+        [object] $PrivateData
+    )
+
+    $outManifest = [ordered]@{}
+    $outPSData = [ordered]@{}
+    $outPrivateData = [ordered]@{}
+
+    $tempManifest = Get-ModuleManifest -Path $Path
+    if ($tempManifest.Keys.Contains('PrivateData')) {
+        $tempPrivateData = $tempManifest.PrivateData
+        if ($tempPrivateData.Keys.Contains('PSData')) {
+            $tempPSData = $tempPrivateData.PSData
+            $tempPrivateData.Remove('PSData')
+        }
+    }
+
+    $psdataOrder = @(
+        'Tags'
+        'LicenseUri'
+        'ProjectUri'
+        'IconUri'
+        'ReleaseNotes'
+        'Prerelease'
+        'RequireLicenseAcceptance'
+        'ExternalModuleDependencies'
+    )
+    foreach ($key in $psdataOrder) {
+        if (($null -ne $tempPSData) -and $tempPSData.Keys.Contains($key)) {
+            $outPSData[$key] = $tempPSData[$key]
+        }
+        if ($PSBoundParameters.Keys.Contains($key)) {
+            if ($null -eq $PSBoundParameters[$key]) {
+                $outPSData.Remove($key)
+            } else {
+                $outPSData[$key] = $PSBoundParameters[$key]
+            }
+        }
+    }
+
+    if ($outPSData.Count -gt 0) {
+        $outPrivateData.PSData = $outPSData
+    } else {
+        $outPrivateData.Remove('PSData')
+    }
+    foreach ($key in $tempPrivateData.Keys) {
+        $outPrivateData[$key] = $tempPrivateData[$key]
+    }
+    foreach ($key in $PrivateData.Keys) {
+        $outPrivateData[$key] = $PrivateData[$key]
+    }
+
+    $manifestOrder = @(
+        'RootModule'
+        'ModuleVersion'
+        'CompatiblePSEditions'
+        'GUID'
+        'Author'
+        'CompanyName'
+        'Copyright'
+        'Description'
+        'PowerShellVersion'
+        'PowerShellHostName'
+        'PowerShellHostVersion'
+        'DotNetFrameworkVersion'
+        'ClrVersion'
+        'ProcessorArchitecture'
+        'RequiredModules'
+        'RequiredAssemblies'
+        'ScriptsToProcess'
+        'TypesToProcess'
+        'FormatsToProcess'
+        'NestedModules'
+        'FunctionsToExport'
+        'CmdletsToExport'
+        'VariablesToExport'
+        'AliasesToExport'
+        'DscResourcesToExport'
+        'ModuleList'
+        'FileList'
+        'HelpInfoURI'
+        'DefaultCommandPrefix'
+        'PrivateData'
+    )
+    foreach ($key in $manifestOrder) {
+        if ($tempManifest.Keys.Contains($key)) {
+            $outManifest[$key] = $tempManifest[$key]
+        }
+        if ($PSBoundParameters.Keys.Contains($key)) {
+            if ($null -eq $PSBoundParameters[$key]) {
+                $outManifest.Remove($key)
+            } else {
+                $outManifest[$key] = $PSBoundParameters[$key]
+            }
+        }
+    }
+    if ($outPrivateData.Count -gt 0) {
+        $outManifest['PrivateData'] = $outPrivateData
+    } else {
+        $outManifest.Remove('PrivateData')
+    }
+
+    Remove-Item -Path $Path -Force
+    Export-PowerShellDataFile -Hashtable $outManifest -Path $Path
+
+}

--- a/scripts/helpers/Build/Show-FileContent.ps1
+++ b/scripts/helpers/Build/Show-FileContent.ps1
@@ -1,0 +1,32 @@
+﻿function Show-FileContent {
+    <#
+        .SYNOPSIS
+        Prints the content of a file with line numbers in front of each line.
+
+        .DESCRIPTION
+        Prints the content of a file with line numbers in front of each line.
+
+        .EXAMPLE
+        $Path = 'C:\Utilities\Show-FileContent.ps1'
+        Show-FileContent -Path $Path
+
+        Shows the content of the file with line numbers in front of each line.
+    #>
+    [CmdletBinding()]
+    param (
+        # The path to the file to show the content of.
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    $content = Get-Content -Path $Path
+    $lineNumber = 1
+    $columnSize = $content.Count.ToString().Length
+    # Foreach line print the line number in front of the line with [    ] around it.
+    # The linenumber should dynamically adjust to the number of digits with the length of the file.
+    foreach ($line in $content) {
+        $lineNumberFormatted = $lineNumber.ToString().PadLeft($columnSize)
+        Write-Host "[$lineNumberFormatted] $line"
+        $lineNumber++
+    }
+}

--- a/scripts/helpers/Build/Update-PSModuleManifestAliasesToExport.ps1
+++ b/scripts/helpers/Build/Update-PSModuleManifestAliasesToExport.ps1
@@ -16,7 +16,6 @@
         Justification = 'Want to just write to the console, not the pipeline.'
     )]
     #Requires -Modules @{ ModuleName = 'GitHub'; ModuleVersion = '0.13.2' }
-    #Requires -Modules @{ ModuleName = 'Utilities'; ModuleVersion = '0.3.0' }
     [CmdletBinding()]
     param(
         # Name of the module.

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -5,8 +5,6 @@
 [CmdletBinding()]
 param()
 
-#Requires -Modules Utilities
-
 $path = (Join-Path -Path $PSScriptRoot -ChildPath 'helpers') | Get-Item | Resolve-Path -Relative
 LogGroup "Loading helper scripts from [$path]" {
     Get-ChildItem -Path $path -Filter '*.ps1' -Recurse | Resolve-Path -Relative | ForEach-Object {
@@ -16,7 +14,7 @@ LogGroup "Loading helper scripts from [$path]" {
 }
 
 LogGroup 'Loading inputs' {
-    $moduleName = ($env:GITHUB_ACTION_INPUT_Name | IsNullOrEmpty) ? $env:GITHUB_REPOSITORY_NAME : $env:GITHUB_ACTION_INPUT_Name
+    $moduleName = [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Name) ? $env:GITHUB_REPOSITORY_NAME : $env:GITHUB_ACTION_INPUT_Name
     Write-Host "Module name:         [$moduleName]"
 
     $moduleSourceFolderPath = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath $env:GITHUB_ACTION_INPUT_Path/$moduleName


### PR DESCRIPTION
## Description

This pull request includes several changes to improve the handling of null or empty string checks in various PowerShell scripts. The updates primarily involve replacing custom `IsNullOrEmpty` function calls with the built-in `[string]::IsNullOrEmpty` method to enhance readability and maintainability.

Improvements to null or empty string checks:

* [`scripts/helpers/Build/Build-PSModuleManifest.ps1`](diffhunk://#diff-50cfb011f5c8aeef8145003927ec3e5edfdf26e5d417bcee6e441517c07454f9L63-R66): Replaced custom `IsNotNullOrEmpty` checks with `[string]::IsNullOrEmpty` for the `Author`, `CompanyName`, and `Description` properties in the module manifest. [[1]](diffhunk://#diff-50cfb011f5c8aeef8145003927ec3e5edfdf26e5d417bcee6e441517c07454f9L63-R66) [[2]](diffhunk://#diff-50cfb011f5c8aeef8145003927ec3e5edfdf26e5d417bcee6e441517c07454f9L76-R76)
* [`scripts/helpers/Build/Get-PSModuleAliasesToExport.ps1`](diffhunk://#diff-ae18191466ffa02c1a8429365cf96d8768f5eae03331c4a35199f8cd961e76a7L33-R34): Updated the check for `AliasesToExport` to use `[string]::IsNullOrEmpty`.
* [`scripts/helpers/Build/Get-PSModuleCmdletsToExport.ps1`](diffhunk://#diff-f542f4a75d778df60fee6e176c795e133be2ed109d8212c05aa545383bd26c46L33-R34): Updated the check for `CmdletsToExport` to use `[string]::IsNullOrEmpty`.
* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L8-L9): Removed unused module requirement and updated the check for `GITHUB_ACTION_INPUT_Name` to use `[string]::IsNullOrEmpty`. [[1]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L8-L9) [[2]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L19-R17)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
