### PR TITLE
🩹 [Patch]: IsWindows PS 5.1 compatibility shim removed

### DIFF
--- a/src/helpers/Build/Build-PSModuleRootModule.ps1
+++ b/src/helpers/Build/Build-PSModuleRootModule.ps1
@@ -131,17 +131,6 @@ $MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
         #endregion - Analyze source files
 
         #region - Module header
-        Add-Content -Path $rootModuleFile -Force -Value @'
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-    'PSAvoidAssignmentToAutomaticVariable', 'IsWindows',
-    Justification = 'IsWindows does not exist in PS5.1'
-)]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-    'PSUseDeclaredVarsMoreThanAssignments', 'IsWindows',
-    Justification = 'IsWindows does not exist in PS5.1'
-)]
-'@
-
         $headerFilePath = Join-Path -Path $ModuleOutputFolder -ChildPath 'header.ps1'
         if (Test-Path -Path $headerFilePath) {
             Get-Content -Path $headerFilePath -Raw | Add-Content -Path $rootModuleFile -Force
@@ -161,10 +150,6 @@ $script:PSModuleInfo = Import-PowerShellDataFile -Path "$PSScriptRoot\$baseName.
 $script:PSModuleInfo | Format-List | Out-String -Stream | ForEach-Object { Write-Debug $_ }
 $scriptName = $script:PSModuleInfo.Name
 Write-Debug "[$scriptName] - Importing module"
-
-if ($PSEdition -eq 'Desktop') {
-    $IsWindows = $true
-}
 
 '@
         #endregion - Module post-header


### PR DESCRIPTION
Built modules no longer include the `$IsWindows = $true` shim or its PSScriptAnalyzer suppression attributes. PSModule targets PowerShell LTS (7.6+), where `$IsWindows` is a built-in automatic variable — the Desktop edition fallback is unnecessary.

## Changed: Built module root files are smaller and cleaner

The generated `.psm1` files no longer contain the following block:

```powershell
[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
    'PSAvoidAssignmentToAutomaticVariable', 'IsWindows',
    Justification = 'IsWindows does not exist in PS5.1'
)]
[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
    'PSUseDeclaredVarsMoreThanAssignments', 'IsWindows',
    Justification = 'IsWindows does not exist in PS5.1'
)]
```

And the module post-header no longer includes:

```powershell
if ($PSEdition -eq 'Desktop') {
    $IsWindows = $true
}
```

Modules built with this version require PowerShell 7.x+ (LTS). If you need PS 5.1 support, pin Build-PSModule to v4.

## Technical Details

- `Build-PSModuleRootModule.ps1`: Removed the `Add-Content` call that injected the two `SuppressMessageAttribute` entries and the empty here-string left after their removal. Removed the `if ($PSEdition -eq 'Desktop')` block from the module post-header template.
- Companion PR in Test-PSModule removes the corresponding framework test for this shim.